### PR TITLE
Use a new UUID for registering as a new package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "FiniteDifferences"
-uuid = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
+uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
 version = "0.7.0"
 
 [deps]


### PR DESCRIPTION
- We intend to register FiniteDifferences.jl as a new package, so we need a new UUID.
- Because renaming the package from FDM -> FiniteDifferences is hard/confusing/undefined behaviour, as far as anyone understands
- Note we'll just continue with the version numbers from FDM, so the next release (registering the package) will have version `0.7`