### PR TITLE
Setup nightly notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ julia:
   - 1.3
   - nightly
 notifications:
-  email: false
+  email:
+    recipients:
+      - nightly-rse@invenia.ca
+    on_success: never
+    on_failure: always
+    if: type = cron
 matrix:
   allow_failures:
     - julia: 1.3


### PR DESCRIPTION
Informs the Invenia team of nightly CI failures. @oxinabox setup the daily Travis CI cron job.