### PR TITLE
Do gradient via mutating and unmutating cell

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -41,7 +41,7 @@ function grad(fdm, f, d::Dict{K, V}) where {K, V}
         ∇d[k] = grad(fdm, f′, v)[1]
         d[k] = dk
     end
-    return (dd, )
+    return (∇d, )
 end
 
 function grad(fdm, f, x)

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -31,14 +31,15 @@ grad(fdm, f, x::Real) = (fdm(f, x), )
 grad(fdm, f, x::Tuple) = (grad(fdm, (xs...)->f(xs), x...), )
 
 function grad(fdm, f, d::Dict{K, V}) where {K, V}
-    dd = Dict{K, V}()
+    ∇d = Dict{K, V}()
     for (k, v) in d
+        dk = d[k]
         function f′(x)
-            tmp = copy(d)
-            tmp[k] = x
-            return f(tmp)
+            d[k] = x
+            return f(d)
         end
-        dd[k] = grad(fdm, f′, v)[1]
+        ∇d[k] = grad(fdm, f′, v)[1]
+        d[k] = dk
     end
     return (dd, )
 end


### PR DESCRIPTION
We can avoid copying every element every step if we just mutate the element we want to mutate on the original matrix, then mutate it back again after so we still have the original for the next step.

My micro benchmarks show this helps a bit.