### PR TITLE
Decrease allocations

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -17,7 +17,7 @@ function _grad(fdm, f, x::AbstractArray{T}) where T <: Number
             x[k] = xk +  ϵ
             ret = f(x)
             x[k] = xk  # Can't do `x[k] -= ϵ` as floating-point math is not associative
-            return ret
+            return ret::T
         end
     end
     return (dx, )

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -41,7 +41,7 @@ function grad(fdm, f, d::Dict{K, V}) where {K, V}
         ∇d[k] = grad(fdm, f′, v)[1]
         d[k] = dk
     end
-    return (dd, )
+    return (∇d, )
 end
 
 function grad(fdm, f, x)

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -31,14 +31,15 @@ grad(fdm, f, x::Real) = (fdm(f, x), )
 grad(fdm, f, x::Tuple) = (grad(fdm, (xs...)->f(xs), x...), )
 
 function grad(fdm, f, d::Dict{K, V}) where {K, V}
-    dd = Dict{K, V}()
+    ∇d = Dict{K, V}()
     for (k, v) in d
+        dk = d[k]
         function f′(x)
-            tmp = copy(d)
-            tmp[k] = x
-            return f(tmp)
+            d[k] = x
+            return f(d)
         end
-        dd[k] = grad(fdm, f′, v)[1]
+        ∇d[k] = grad(fdm, f′, v)[1]
+        d[k] = dk
     end
     return (dd, )
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -181,6 +181,7 @@ The recognized keywords are:
 * `bound`: Bound on the value of the function and its derivatives at `x`.
 * `condition`: The condition number. See [`DEFAULT_CONDITION`](@ref).
 * `eps`: The assumed roundoff error. Defaults to `eps()` plus [`TINY`](@ref).
+* `track_history`: wether to update the history of the method `m` with e.g. accuracy stats.
 
 !!! warning
     Bounds can't be adaptively computed over nonstandard grids; passing a value for
@@ -211,14 +212,15 @@ julia> fdm(central_fdm(2, 1), exp, 0, Val(true))
 function fdm(
     m::M,
     f,
-    x,
+    x::T,
     ::Val{true};
     condition=DEFAULT_CONDITION,
-    bound=_estimate_bound(f(x), condition),
-    eps=(Base.eps(float(bound)) + TINY),
+    bound::T=_estimate_bound(f(x)::T, condition)::T,
+    eps::T=(Base.eps(float(bound)) + TINY)::T,
     adapt=m.history.adapt,
     max_step=0.1,
-) where M<:FiniteDifferenceMethod
+    track_history=true  # will be set to false if `Val{false}()` used
+)::Tuple{M, T} where {M<:FiniteDifferenceMethod, T}
     if M <: Nonstandard && adapt > 0
         throw(ArgumentError("can't adaptively compute bounds over Nonstandard grids"))
     end
@@ -256,22 +258,25 @@ function fdm(
     C₂ = bound * sum(n->abs(coefs[n] * grid[n]^p), eachindex(coefs)) / factorial(p)
     ĥ = min((q / (p - q) * C₁ / C₂)^(1 / p), max_step)
 
-    # Estimate the accuracy of the method.
-    accuracy = ĥ^(-q) * C₁ + ĥ^(p - q) * C₂
-
     # Estimate the value of the derivative.
-    dfdx = sum(i->coefs[i] * f(x + ĥ * grid[i]), eachindex(grid)) / ĥ^q
+    dfdx_s = sum(eachindex(grid)) do i
+        (@inbounds coefs[i] * f(x + ĥ * grid[i]))::T
+    end
+    dfdx = dfdx_s / ĥ^q
 
-    m.history.eps = eps
-    m.history.bound = bound
-    m.history.step = ĥ
-    m.history.accuracy = accuracy
-
+    if track_history
+        # Estimate the accuracy of the method.
+        accuracy = ĥ^(-q) * C₁ + ĥ^(p - q) * C₂
+        m.history.eps = eps
+        m.history.bound = bound
+        m.history.step = ĥ
+        m.history.accuracy = accuracy
+    end
     return m, dfdx
 end
 
 function fdm(m::FiniteDifferenceMethod, f, x, ::Val{false}=Val(false); kwargs...)
-    _, dfdx = fdm(m, f, x, Val(true); kwargs...)
+    _, dfdx = fdm(m, f, x, Val{true}(); track_history=false, kwargs...)
     return dfdx
 end
 


### PR DESCRIPTION
Turns out type-stability was causing a bunch of allocations.
Type inference was failing for some reason.

Also tracking history surpisingly, causes allocations.
We don't need to track history when doing grad anyway.

This is built ontop of #59  and that should be merged first.

```
using BenchmarkTools
using FiniteDifferences

const _fdm = central_fdm(2,1);
const _fdm5 = central_fdm(5,1);

const xs = collect(1:0.1:200);
f(x) = sum(sin, x);
@btime grad($_fdm, $f, $xs);
@btime grad($_fdm5, $f, $xs);
```

This PR decreases allocation count by >60%
and decreases allocation amoun t by >30%.

But that does not translate directly into speed.
I guess it won't pay off much til the garbage collector gets avoided...

### Current (oxmut1)
```
julia> @btime grad($_fdm, $f, $xs);
  202.552 ms (154789 allocations: 4.26 MiB)

julia> @btime grad($_fdm5, $f, $xs);
  413.311 ms (162753 allocations: 5.45 MiB)
```
-----------------

### New with Stability improvements
```
julia> @btime grad($_fdm, $f, $xs);
  200.205 ms (49777 allocations: 2.66 MiB)

julia> @btime grad($_fdm5, $f, $xs);
  398.832 ms (59732 allocations: 3.87 MiB)
```