### PR TITLE
Compute coeffs using Rationals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -157,10 +157,12 @@ end
 
 # Compute coefficients for the method
 function _coefs(grid::AbstractVector{<:Real}, p::Integer, q::Integer)
-    C = [g^i for i in 0:(p - 1), g in grid]
-    x = zeros(Int, p)
+    # For high precision on the \ we use Rational, and to prevent overfloats we use Int128
+    # At the end we go to Float64 for fast floating point math (rather than rational math)
+    C = [Rational{Int128}(g^i) for i in 0:(p - 1), g in grid]
+    x = zeros(Rational{Int128}, p)
     x[q + 1] = factorial(q)
-    return C \ x
+    return Float64.(C \ x)
 end
 
 # Estimate the bound on the function value and its derivatives at a point

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -157,7 +157,7 @@ end
 
 # Compute coefficients for the method
 function _coefs(grid::AbstractVector{<:Real}, p::Integer, q::Integer)
-    # For high precision on the \ we use Rational, and to prevent overfloats we use Int128
+    # For high precision on the \ we use Rational, and to prevent overflows we use Int128
     # At the end we go to Float64 for fast floating point math (rather than rational math)
     C = [Rational{Int128}(g^i) for i in 0:(p - 1), g in grid]
     x = zeros(Rational{Int128}, p)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -37,6 +37,17 @@ using FiniteDifferences: Forward, Backward, Central, Nonstandard
         @test central_fdm(5, 1)(abs, 0.001) ≈ 1.0
     end
 
+    @testset "Accuracy at high orders, with high adapt" begin
+        # Regression test against issues with precision during computation of _coeffs
+        # see https://github.com/JuliaDiff/FiniteDifferences.jl/issues/64
+
+        @test fdm(central_fdm(9, 5), exp, 1.0, adapt=4) ≈ exp(1) atol=1e-7
+
+        poly(x) = 4x^3 + 3x^2 + 2x + 1
+        @test fdm(central_fdm(9, 3), poly, 1.0, adapt=4) ≈ 24 atol=1e-11
+    end
+
+
     @testset "Printing FiniteDifferenceMethods" begin
         @test sprint(show, central_fdm(2, 1)) == """
             FiniteDifferenceMethod:


### PR DESCRIPTION
Fixed #64 

Turns out this can make a difference.

This not only gets result on julia 1.4 up to the standard of julia 1.2,
but actually does much more than that, significantly improving out accuracy

### With this PR. in julia 1.2 or 1.4 (identical):
```julia
julia> using FiniteDifferences

julia> k3 = FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 5), y->exp(y), 1.0, adapt=4)
2.7182817496168528

julia> abs(k3-exp(1))  # Should be 0
7.884219233034173e-8

julia> f(x) = @. 4x^3 + 3x^2 + 2x + 1
f (generic function with 1 method)

julia> FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 3), f, 1.0, adapt=4) - 24
5.538680625249981e-12
```

## Without this PR. 1.4
```julia
julia> using FiniteDifferences

julia> k3 = FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 5), y->exp(y), 1.0, adapt=4)
2.7182663156747684

julia> abs(k3-exp(1))  # Should be 0
1.5512784276694447e-5

julia> f(x) = @. 4x^3 + 3x^2 + 2x + 1
f (generic function with 1 method)

julia> FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 3), f, 1.0, adapt=4) - 24
6.48253006829691e-10
```

### Without this PR on 1.2
```julia
julia> using FiniteDifferences

julia> k3 = FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 5), y->exp(y), 1.0, adapt=4)
2.7182815825355453

julia> abs(k3-exp(1))  # Should be 0
2.459234997864712e-7

julia> f(x) = @. 4x^3 + 3x^2 + 2x + 1
f (generic function with 1 method)

julia> FiniteDifferences.fdm(FiniteDifferences.central_fdm(9, 3), f, 1.0, adapt=4) - 24
1.071143174158351e-11
```

---

I feel like this is going to increase our cost a fair bit.
So it would be really good to get #61 done, to avoid recomputing coeffs.