### PR TITLE
Refactor jacobian and grad

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.10.0"
+version = "0.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FiniteDifferences.jl
+++ b/src/FiniteDifferences.jl
@@ -2,8 +2,6 @@ module FiniteDifferences
 
     using Printf, LinearAlgebra
 
-    const AV = AbstractVector
-
     include("methods.jl")
     include("numerics.jl")
     include("to_vec.jl")

--- a/src/FiniteDifferences.jl
+++ b/src/FiniteDifferences.jl
@@ -2,6 +2,8 @@ module FiniteDifferences
 
     using Printf, LinearAlgebra
 
+    export to_vec, grad, jacobian, jvp, j′vp
+
     include("methods.jl")
     include("numerics.jl")
     include("to_vec.jl")

--- a/src/FiniteDifferences.jl
+++ b/src/FiniteDifferences.jl
@@ -6,8 +6,6 @@ module FiniteDifferences
 
     include("methods.jl")
     include("numerics.jl")
+    include("to_vec.jl")
     include("grad.jl")
-
-
-    @deprecate jacobian(fdm, f, x::Vector, D::Int) jacobian(fdm, f, x; len=D)
 end

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -6,7 +6,8 @@ Approximate the Jacobian of `f` at `x` using `fdm`. Results will be returned as 
 version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening performed by
 [`to_vec`](@ref).
 """
-function jacobian(fdm, f, x::Vector{<:Number})
+function jacobian(fdm, f, x::Vector{<:Number}; len=nothing)
+    len !== nothing && Base.depwarn("len parameter to jacobian is deprecated", :jacobian)
     ẏs = map(eachindex(x)) do n
         return fdm(zero(eltype(x))) do ε
             xn = x[n]
@@ -19,14 +20,14 @@ function jacobian(fdm, f, x::Vector{<:Number})
     return (hcat(ẏs...), )
 end
 
-function jacobian(fdm, f, x)
+function jacobian(fdm, f, x; len=nothing)
     x_vec, from_vec = to_vec(x)
-    return jacobian(fdm, f ∘ from_vec, x_vec)
+    return jacobian(fdm, f ∘ from_vec, x_vec; len=len)
 end
 
-function jacobian(fdm, f, xs...)
+function jacobian(fdm, f, xs...; len=nothing)
     return ntuple(length(xs)) do k
-        jacobian(fdm, x->f(replace_arg(x, xs, k)...), xs[k])[1]
+        jacobian(fdm, x->f(replace_arg(x, xs, k)...), xs[k]; len=len)[1]
     end
 end
 

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -6,7 +6,7 @@ export grad, jacobian, jvp, j′vp
 Approximate the Jacobian of `f` at `x` using `fdm`. Results will be returned as a
 `Matrix{<:Number}` of `size(length(y_vec), length(x_vec))` where `x_vec` is the flattened
 version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening performed by
-`to_vec`.
+[`to_vec`](@ref).
 """
 function jacobian(fdm, f, x::Vector{<:Number})
     ẏs = map(eachindex(x)) do n

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -81,4 +81,4 @@ j′vp(fdm, f, ȳ, xs...) = j′vp(fdm, xs->f(xs...), ȳ, xs)[1]
 
 Compute the gradient of `f` for any `xs` for which [`to_vec`](@ref) is defined.
 """
-grad(fdm, f, xs...) = j′vp(fdm, f, 1, xs...)
+grad(fdm, f, xs...) = j′vp(fdm, f, 1, xs...)  # `j′vp` with seed of 1

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -13,7 +13,7 @@ function jacobian(fdm, f, x::Vector{<:Number}; len=nothing)
             xn = x[n]
             x[n] = xn + ε
             ret = first(to_vec(f(x)))
-            x[n] = xn  # undo addition of  `ε` to input
+            x[n] = xn  # Can't do `x[k] -= ϵ` as floating-point math is not associative
             return ret
         end
     end

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -1,4 +1,4 @@
-export grad, jacobian, jvp, j′vp, to_vec
+export grad, jacobian, jvp, j′vp
 
 """
     jacobian(fdm, f, x...)
@@ -71,7 +71,7 @@ end
 function j′vp(fdm, f, ȳ, x)
     x_vec, vec_to_x = to_vec(x)
     ȳ_vec, _ = to_vec(ȳ)
-    return (vec_to_x(_j′vp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], ȳ_vec, x_vec)), )
+    return (vec_to_x(_j′vp(fdm, first ∘ to_vec ∘ f ∘ vec_to_x, ȳ_vec, x_vec)), )
 end
 
 j′vp(fdm, f, ȳ, xs...) = j′vp(fdm, xs->f(xs...), ȳ, xs)[1]

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -8,7 +8,7 @@ version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening perfo
 """
 function jacobian(fdm, f, x::Vector{<:Number}; len=nothing)
     len !== nothing && Base.depwarn(
-        "`len` keyword argument to `jacobian` is nolonger required " *
+        "`len` keyword argument to `jacobian` is no longer required " *
         "and will not be permitted in the future.",
          :jacobian
     )

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -14,7 +14,7 @@ function jacobian(fdm, f, x::Vector{<:Number})
             xn = x[n]
             x[n] = xn + ε
             ret = first(to_vec(f(x))
-            x[n] = xn
+            x[n] = xn  # undo addition of  `ε` to input
             return ret
         end
     end

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -17,7 +17,7 @@ function jacobian(fdm, f, x::Vector{<:Number}; len=nothing)
             xn = x[n]
             x[n] = xn + ε
             ret = first(to_vec(f(x)))
-            x[n] = xn  # Can't do `x[k] -= ϵ` as floating-point math is not associative
+            x[n] = xn  # Can't do `x[n] -= ϵ` as floating-point math is not associative
             return ret
         end
     end

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -1,7 +1,5 @@
 export grad, jacobian, jvp, j′vp, to_vec
 
-replace_arg(x, xs::Tuple, k::Int) = ntuple(p -> p == k ? x : xs[p], length(xs))
-
 """
     jacobian(fdm, f, x...)
 
@@ -11,36 +9,15 @@ version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening perfo
 `to_vec`.
 """
 function jacobian(fdm, f, x::Vector{<:Number})
-
-    # Construct a transformation of f that outputs Vector{<:Number}.
-    f_vec = first ∘ to_vec ∘ f
-
-    # Compute the first element so that we know what the output type is.
-    ẏ = fdm(zero(eltype(x))) do ε
-        x1 = x[1]
-        x[1] = x1 + ε
-        ret = f_vec(x)
-        x[1] = x1
-        return ret
-    end
-
-    # Allocate for the sensitivities.
-    @assert ẏ isa Vector{<:Number}
-    ẏs = Vector{typeof(ẏ)}(undef, length(x))
-    ẏs[1] = ẏ
-
-    # Iterate over the remainder of the input elements.
-    for n in 2:length(x)
-        ẏs[n] = fdm(zero(eltype(x))) do ε
+    ẏs = map(eachindex(x)) do n
+        return fdm(zero(eltype(x))) do ε
             xn = x[n]
             x[n] = xn + ε
-            ret = f_vec(x)
+            ret = (first ∘ to_vec ∘ f)(x)
             x[n] = xn
             return ret
         end
     end
-
-    # Spit out a 1-Tuple containing a Matrix{<:Number}.
     return (hcat(ẏs...), )
 end
 
@@ -55,26 +32,7 @@ function jacobian(fdm, f, xs...)
     end
 end
 
-
-"""
-    grad(fdm, f, xs...)
-
-Approximate the gradient of `f` at `xs...` using `fdm`. Requires that `f(xs...)` is scalar.
-"""
-function grad(fdm, f, x)
-    x_vec, from_vec = to_vec(x)
-    J = first(jacobian(fdm, f ∘ from_vec, x_vec))
-    @assert size(J, 1) == 1
-    return (from_vec(vec(J)), )
-end
-
-function grad(fdm, f, xs...)
-    return ntuple(length(xs)) do k
-        grad(fdm, x->f(replace_arg(x, xs, k)...), xs[k])[1]
-    end
-end
-
-
+replace_arg(x, xs::Tuple, k::Int) = ntuple(p -> p == k ? x : xs[p], length(xs))
 
 """
     _jvp(fdm, f, x::Vector{<:Number}, ẋ::AbstractVector{<:Number})
@@ -101,24 +59,26 @@ function jvp(fdm, f, xẋs::Tuple{Any, Any}...)
     return jvp(fdm, xs->f(xs...)[1], (x, ẋ))
 end
 
-
-"""
-    j′vp(fdm, f, ȳ::AbstractVector{<:Number}, x::Vector{<:Number})
-
-Convenience function to compute `transpose(jacobian(f, x)) * ȳ`.
-"""
-function _j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Number})
-    return transpose(jacobian(fdm, f, x)[1]) * ȳ
-end
-
 """
     j′vp(fdm, f, ȳ, x...)
 
 Compute an adjoint with any types of arguments for which [`to_vec`](@ref) is defined.
 """
+function _j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Number})
+    return transpose(jacobian(fdm, f, x)[1]) * ȳ
+end
+
 function j′vp(fdm, f, ȳ, x)
     x_vec, vec_to_x = to_vec(x)
     ȳ_vec, _ = to_vec(ȳ)
     return (vec_to_x(_j′vp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], ȳ_vec, x_vec)), )
 end
+
 j′vp(fdm, f, ȳ, xs...) = j′vp(fdm, xs->f(xs...), ȳ, xs)[1]
+
+"""
+    grad(fdm, f, xs...)
+
+Compute the gradient of `f` for any `xs` for which [`to_vec`](@ref) is defined.
+"""
+grad(fdm, f, xs...) = j′vp(fdm, f, 1, xs...)

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -7,7 +7,11 @@ version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening perfo
 [`to_vec`](@ref).
 """
 function jacobian(fdm, f, x::Vector{<:Number}; len=nothing)
-    len !== nothing && Base.depwarn("len parameter to jacobian is deprecated", :jacobian)
+    len !== nothing && Base.depwarn(
+        "`len` keyword argument to `jacobian` is nolonger required " *
+        "and will not be permitted in the future.",
+         :jacobian
+    )
     ẏs = map(eachindex(x)) do n
         return fdm(zero(eltype(x))) do ε
             xn = x[n]

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -13,7 +13,7 @@ function jacobian(fdm, f, x::Vector{<:Number})
         return fdm(zero(eltype(x))) do ε
             xn = x[n]
             x[n] = xn + ε
-            ret = (first ∘ to_vec ∘ f)(x)
+            ret = first(to_vec(f(x))
             x[n] = xn
             return ret
         end

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -11,7 +11,7 @@ function jacobian(fdm, f, x::Vector{<:Number})
         return fdm(zero(eltype(x))) do ε
             xn = x[n]
             x[n] = xn + ε
-            ret = first(to_vec(f(x))
+            ret = first(to_vec(f(x)))
             x[n] = xn  # undo addition of  `ε` to input
             return ret
         end
@@ -60,12 +60,8 @@ end
 """
     j′vp(fdm, f, ȳ, x...)
 
-Compute an adjoint with any types of arguments for which [`to_vec`](@ref) is defined.
+Compute an adjoint with any types of arguments `x` for which [`to_vec`](@ref) is defined.
 """
-function _j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Number})
-    return transpose(jacobian(fdm, f, x)[1]) * ȳ
-end
-
 function j′vp(fdm, f, ȳ, x)
     x_vec, vec_to_x = to_vec(x)
     ȳ_vec, _ = to_vec(ȳ)
@@ -73,6 +69,10 @@ function j′vp(fdm, f, ȳ, x)
 end
 
 j′vp(fdm, f, ȳ, xs...) = j′vp(fdm, xs->f(xs...), ȳ, xs)[1]
+
+function _j′vp(fdm, f, ȳ::Vector{<:Number}, x::Vector{<:Number})
+    return transpose(first(jacobian(fdm, f, x))) * ȳ
+end
 
 """
     grad(fdm, f, xs...)

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -1,5 +1,3 @@
-export grad, jacobian, jvp, j′vp
-
 """
     jacobian(fdm, f, x...)
 

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -1,3 +1,5 @@
+export to_vec
+
 """
     to_vec(x)
 

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -16,8 +16,8 @@ function to_vec(x::Vector)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     function Vector_from_vec(x_vec)
-        sz = cumsum([map(length, x_vecs)...])
-        return [backs[n](x_vec[sz[n]-length(x_vecs[n])+1:sz[n]]) for n in eachindex(x)]
+        sz = cumsum(map(length, x_vecs))
+        return [backs[n](x_vec[sz[n] - length(x_vecs[n]) + 1:sz[n]]) for n in eachindex(x)]
     end
     return vcat(x_vecs...), Vector_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -92,7 +92,8 @@ function to_vec(d::Dict)
     d_vec, back = to_vec(d_vec_vec)
     function Dict_from_vec(v)
         v_vec_vec = back(v)
-        return Dict([(key, v_vec_vec[n]) for (n, key) in enumerate(keys(d))])
+        return Dict(key => v_vec_vec[n] for (n, key) in enumerate(keys(d)))
+        # return Dict([(key, v_vec_vec[n]) for (n, key) in enumerate(keys(d))])
     end
     return d_vec, Dict_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -85,7 +85,7 @@ function to_vec(x::Tuple)
     function Tuple_from_vec(v)
         return ntuple(n->x_backs[n](v[sz[n]-length(x_vecs[n])+1:sz[n]]), length(x))
     end
-    return vcat(x_vecs...), Tuple_from_vec
+    return reduce(vcat, x_vecs), Tuple_from_vec
 end
 
 # Convert to a vector-of-vectors to make use of existing functionality.

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -1,7 +1,8 @@
 """
     to_vec(x)
 
-Transform `x` into a `Vector`, and return the vector, and a closure which inverts the transformation.
+Transform `x` into a `Vector`, and return the vector, and a closure which inverts the
+transformation.
 """
 function to_vec(x::Number)
     function Number_from_vec(x_vec)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -1,0 +1,98 @@
+"""
+    to_vec(x)
+
+Transform `x` into a `Vector`, and return a closure which inverts the transformation.
+"""
+function to_vec(x::Number)
+    function Number_from_vec(x_vec)
+        return first(x_vec)
+    end
+    return [x], Number_from_vec
+end
+
+# Vectors
+to_vec(x::Vector{<:Number}) = (x, identity)
+function to_vec(x::Vector)
+    x_vecs_and_backs = map(to_vec, x)
+    x_vecs, backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
+    function Vector_from_vec(x_vec)
+        sz = cumsum([map(length, x_vecs)...])
+        return [backs[n](x_vec[sz[n]-length(x_vecs[n])+1:sz[n]]) for n in eachindex(x)]
+    end
+    return vcat(x_vecs...), Vector_from_vec
+end
+
+# Arrays
+function to_vec(x::Array{<:Number})
+    function Array_from_vec(x_vec)
+        return reshape(x_vec, size(x))
+    end
+    return vec(x), Array_from_vec
+end
+
+function to_vec(x::Array)
+    x_vec, back = to_vec(reshape(x, :))
+    function Array_from_vec(x_vec)
+        return reshape(back(x_vec), size(x))
+    end
+    return x_vec, Array_from_vec
+end
+
+# AbstractArrays
+function to_vec(x::T) where {T<:LinearAlgebra.AbstractTriangular}
+    x_vec, back = to_vec(Matrix(x))
+    function AbstractTriangular_from_vec(x_vec)
+        return T(reshape(back(x_vec), size(x)))
+    end
+    return x_vec, AbstractTriangular_from_vec
+end
+
+function to_vec(x::Symmetric)
+    function Symmetric_from_vec(x_vec)
+        return Symmetric(reshape(x_vec, size(x)))
+    end
+    return vec(Matrix(x)), Symmetric_from_vec
+end
+
+function to_vec(X::Diagonal)
+    function Diagonal_from_vec(x_vec)
+        return Diagonal(reshape(x_vec, size(X)...))
+    end
+    return vec(Matrix(X)), Diagonal_from_vec
+end
+
+function to_vec(X::Transpose)
+    function Transpose_from_vec(x_vec)
+        return Transpose(permutedims(reshape(x_vec, size(X))))
+    end
+    return vec(Matrix(X)), Transpose_from_vec
+end
+
+function to_vec(X::Adjoint)
+    function Adjoint_from_vec(x_vec)
+        return Adjoint(conj!(permutedims(reshape(x_vec, size(X)))))
+    end
+    return vec(Matrix(X)), Adjoint_from_vec
+end
+
+# Non-array data structures
+
+function to_vec(x::Tuple)
+    x_vecs, x_backs = zip(map(to_vec, x)...)
+    sz = cumsum([map(length, x_vecs)...])
+    function Tuple_from_vec(v)
+        return ntuple(n->x_backs[n](v[sz[n]-length(x_vecs[n])+1:sz[n]]), length(x))
+    end
+    return vcat(x_vecs...), Tuple_from_vec
+end
+
+# Convert to a vector-of-vectors to make use of existing functionality.
+function to_vec(d::Dict)
+    d_vec_vec = [val for val in values(d)]
+    d_vec, back = to_vec(d_vec_vec)
+    function Dict_from_vec(v)
+        v_vec_vec = back(v)
+        return Dict([(key, v_vec_vec[n]) for (n, key) in enumerate(keys(d))])
+    end
+    return d_vec, Dict_from_vec
+end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -88,12 +88,10 @@ end
 
 # Convert to a vector-of-vectors to make use of existing functionality.
 function to_vec(d::Dict)
-    d_vec_vec = [val for val in values(d)]
-    d_vec, back = to_vec(d_vec_vec)
+    d_vec, back = to_vec(collect(values(d)))
     function Dict_from_vec(v)
         v_vec_vec = back(v)
         return Dict(key => v_vec_vec[n] for (n, key) in enumerate(keys(d)))
-        # return Dict([(key, v_vec_vec[n]) for (n, key) in enumerate(keys(d))])
     end
     return d_vec, Dict_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -1,5 +1,3 @@
-export to_vec
-
 """
     to_vec(x)
 

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -3,7 +3,7 @@ export to_vec
 """
     to_vec(x)
 
-Transform `x` into a `Vector`, and return a closure which inverts the transformation.
+Transform `x` into a `Vector`, and return the vector, and a closure which inverts the transformation.
 """
 function to_vec(x::Number)
     function Number_from_vec(x_vec)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -79,9 +79,11 @@ end
 
 function to_vec(x::Tuple)
     x_vecs, x_backs = zip(map(to_vec, x)...)
-    sz = cumsum([map(length, x_vecs)...])
+    sz = cumsum(collect(map(length, x_vecs)))
     function Tuple_from_vec(v)
-        return ntuple(n->x_backs[n](v[sz[n]-length(x_vecs[n])+1:sz[n]]), length(x))
+        return ntuple(length(x)) do n
+            return x_backs[n](v[sz[n] - length(x_vecs[n]) + 1:sz[n]])
+        end
     end
     return reduce(vcat, x_vecs), Tuple_from_vec
 end

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -1,19 +1,5 @@
 using FiniteDifferences: grad, jacobian, _jvp, _j′vp, jvp, j′vp, to_vec
 
-# Dummy type where length(x::DummyType) ≠ length(first(to_vec(x)))
-struct DummyType{TX<:Matrix}
-    X::TX
-end
-
-function FiniteDifferences.to_vec(x::DummyType)
-    x_vec, back = to_vec(x.X)
-    return x_vec, x_vec -> DummyType(back(x_vec))
-end
-
-Base.:(==)(x::DummyType, y::DummyType) = x.X == y.X
-Base.length(x::DummyType) = size(x.X, 1)
-
-
 @testset "grad" begin
 
     @testset "jvp(::$T)" for T in (Float64, ComplexF64)

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -101,21 +101,21 @@ Base.length(x::DummyType) = size(x.X, 1)
             end
 
             @testset "check mixed scalar & matrices" begin
-                x, y = rand(rng, 3, 3), 2
+                x, y = rand(rng, 3, 3), 2.0
                 dxs = grad(fdm, f2, x, y)
                 @test dxs[1] ≈ grad(fdm, x->f2(x, y), x)[1]
                 @test dxs[2] ≈ grad(fdm, y->f2(x, y), y)[1]
             end
 
             @testset "check tuple" begin
-                x, y = rand(rng, 3, 3), 2
+                x, y = rand(rng, 3, 3), 2.0
                 dxs = grad(fdm, f3, (x, y))[1]
                 @test dxs[1] ≈ grad(fdm, x->f3((x, y)), x)[1]
                 @test dxs[2] ≈ grad(fdm, y->f3((x, y)), y)[1]   
             end
 
             @testset "check dict" begin
-                x, y = rand(rng, 3, 3), 2
+                x, y = rand(rng, 3, 3), 2.0
                 d = Dict(:x=>x, :y=>y)
                 dxs = grad(fdm, f4, d)[1]
                 @test dxs[:x] ≈ grad(fdm, x->f3((x, y)), x)[1]

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -1,4 +1,4 @@
-using FiniteDifferences: grad, jacobian, _jvp, _j′vp, jvp, j′vp, to_vec
+using FiniteDifferences: grad, jacobian, _jvp, jvp, j′vp, _j′vp, to_vec
 
 @testset "grad" begin
 

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -16,6 +16,18 @@ Base.length(x::DummyType) = size(x.X, 1)
 
 @testset "grad" begin
 
+    @testset "jvp(::$T)" for T in (Float64, ComplexF64)
+        rng, N, M, fdm = MersenneTwister(123456), 2, 3, central_fdm(5, 1)
+        x, y = randn(rng, T, N), randn(rng, T, M)
+        ẋ, ẏ = randn(rng, T, N), randn(rng, T, M)
+        xy, ẋẏ = vcat(x, y), vcat(ẋ, ẏ)
+        ż_manual = _jvp(fdm, (xy)->sum(sin, xy), xy, ẋẏ)[1]
+        ż_auto = jvp(fdm, x->sum(sin, x[1]) + sum(sin, x[2]), ((x, y), (ẋ, ẏ)))
+        ż_multi = jvp(fdm, (x, y)->sum(sin, x) + sum(sin, y), (x, ẋ), (y, ẏ))
+        @test ż_manual ≈ ż_auto
+        @test ż_manual ≈ ż_multi
+    end
+
     @testset "grad(::$T)" for T in (Float64, ComplexF64)
         rng, fdm = MersenneTwister(123456), central_fdm(5, 1)
         x = randn(rng, T, 2)
@@ -73,7 +85,7 @@ Base.length(x::DummyType) = size(x.X, 1)
             end
 
             @testset "check mixed scalar and matrices" begin
-                x, y = rand(3, 3), 2
+                x, y = rand(3, 3), 2.0
                 jac_xs = jacobian(fdm, f1, x, y)
                 @test jac_xs[1] ≈ jacobian(fdm, x->f1(x, y), x)[1]
                 @test jac_xs[2] ≈ jacobian(fdm, y->f1(x, y), y)[1]
@@ -110,69 +122,6 @@ Base.length(x::DummyType) = size(x.X, 1)
                 @test dxs[:y] ≈ grad(fdm, y->f3((x, y)), y)[1]
             end
         end
-    end
-
-    function test_to_vec(x)
-        x_vec, back = to_vec(x)
-        @test x_vec isa Vector
-        @test x == back(x_vec)
-        return nothing
-    end
-
-    @testset "to_vec(::$T)" for T in (Float64, ComplexF64)
-        if T == Float64
-            test_to_vec(1.0)
-            test_to_vec(1)
-        else
-            test_to_vec(.7 + .8im)
-            test_to_vec(1 + 2im)
-        end
-        test_to_vec(randn(T, 3))
-        test_to_vec(randn(T, 5, 11))
-        test_to_vec(randn(T, 13, 17, 19))
-        test_to_vec(randn(T, 13, 0, 19))
-        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0])
-        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
-        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
-        test_to_vec(UpperTriangular(randn(T, 13, 13)))
-        test_to_vec(Symmetric(randn(T, 11, 11)))
-        test_to_vec(Diagonal(randn(T, 7)))
-        test_to_vec(DummyType(randn(T, 2, 9)))
-    
-        @testset "$Op" for Op in (Adjoint, Transpose)
-            test_to_vec(Op(randn(T, 4, 4)))
-            test_to_vec(Op(randn(T, 6)))
-            test_to_vec(Op(randn(T, 2, 5)))
-        end
-    
-        @testset "Tuples" begin
-            test_to_vec((5, 4))
-            test_to_vec((5, randn(T, 5)))
-            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1))
-            test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
-            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)))
-            test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
-            test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
-        end
-        @testset "Dictionary" begin
-            if T == Float64
-                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)))
-            else
-                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
-            end
-        end
-    end
-
-    @testset "jvp(::$T)" for T in (Float64, ComplexF64)
-        rng, N, M, fdm = MersenneTwister(123456), 2, 3, central_fdm(5, 1)
-        x, y = randn(rng, T, N), randn(rng, T, M)
-        ẋ, ẏ = randn(rng, T, N), randn(rng, T, M)
-        xy, ẋẏ = vcat(x, y), vcat(ẋ, ẏ)
-        ż_manual = _jvp(fdm, (xy)->sum(sin, xy), xy, ẋẏ)[1]
-        ż_auto = jvp(fdm, x->sum(sin, x[1]) + sum(sin, x[2]), ((x, y), (ẋ, ẏ)))
-        ż_multi = jvp(fdm, (x, y)->sum(sin, x) + sum(sin, y), (x, ẋ), (y, ẏ))
-        @test ż_manual ≈ ż_auto
-        @test ż_manual ≈ ż_multi
     end
 
     @testset "j′vp(::$T)" for T in (Float64, ComplexF64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using FiniteDifferences, Test, Random, Printf, LinearAlgebra
 @testset "FiniteDifferences" begin
     include("methods.jl")
     include("numerics.jl")
+    include("to_vec.jl")
     include("grad.jl")
 end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -1,0 +1,50 @@
+function test_to_vec(x)
+    x_vec, back = to_vec(x)
+    @test x_vec isa Vector
+    @test x == back(x_vec)
+    return nothing
+end
+
+@testset "to_vec(::$T)" for T in (Float64, ComplexF64)
+    if T == Float64
+        test_to_vec(1.0)
+        test_to_vec(1)
+    else
+        test_to_vec(.7 + .8im)
+        test_to_vec(1 + 2im)
+    end
+    test_to_vec(randn(T, 3))
+    test_to_vec(randn(T, 5, 11))
+    test_to_vec(randn(T, 13, 17, 19))
+    test_to_vec(randn(T, 13, 0, 19))
+    test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0])
+    test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
+    test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
+    test_to_vec(UpperTriangular(randn(T, 13, 13)))
+    test_to_vec(Symmetric(randn(T, 11, 11)))
+    test_to_vec(Diagonal(randn(T, 7)))
+    test_to_vec(DummyType(randn(T, 2, 9)))
+
+    @testset "$Op" for Op in (Adjoint, Transpose)
+        test_to_vec(Op(randn(T, 4, 4)))
+        test_to_vec(Op(randn(T, 6)))
+        test_to_vec(Op(randn(T, 2, 5)))
+    end
+
+    @testset "Tuples" begin
+        test_to_vec((5, 4))
+        test_to_vec((5, randn(T, 5)))
+        test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1))
+        test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
+        test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)))
+        test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
+        test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
+    end
+    @testset "Dictionary" begin
+        if T == Float64
+            test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)))
+        else
+            test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
+        end
+    end
+end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -5,46 +5,48 @@ function test_to_vec(x)
     return nothing
 end
 
-@testset "to_vec(::$T)" for T in (Float64, ComplexF64)
-    if T == Float64
-        test_to_vec(1.0)
-        test_to_vec(1)
-    else
-        test_to_vec(.7 + .8im)
-        test_to_vec(1 + 2im)
-    end
-    test_to_vec(randn(T, 3))
-    test_to_vec(randn(T, 5, 11))
-    test_to_vec(randn(T, 13, 17, 19))
-    test_to_vec(randn(T, 13, 0, 19))
-    test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0])
-    test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
-    test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
-    test_to_vec(UpperTriangular(randn(T, 13, 13)))
-    test_to_vec(Symmetric(randn(T, 11, 11)))
-    test_to_vec(Diagonal(randn(T, 7)))
-    test_to_vec(DummyType(randn(T, 2, 9)))
-
-    @testset "$Op" for Op in (Adjoint, Transpose)
-        test_to_vec(Op(randn(T, 4, 4)))
-        test_to_vec(Op(randn(T, 6)))
-        test_to_vec(Op(randn(T, 2, 5)))
-    end
-
-    @testset "Tuples" begin
-        test_to_vec((5, 4))
-        test_to_vec((5, randn(T, 5)))
-        test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1))
-        test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
-        test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)))
-        test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
-        test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
-    end
-    @testset "Dictionary" begin
+@testset "to_vec" begin
+    @testset "$T" for T in (Float64, ComplexF64)
         if T == Float64
-            test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)))
+            test_to_vec(1.0)
+            test_to_vec(1)
         else
-            test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
+            test_to_vec(.7 + .8im)
+            test_to_vec(1 + 2im)
+        end
+        test_to_vec(randn(T, 3))
+        test_to_vec(randn(T, 5, 11))
+        test_to_vec(randn(T, 13, 17, 19))
+        test_to_vec(randn(T, 13, 0, 19))
+        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0])
+        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
+        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
+        test_to_vec(UpperTriangular(randn(T, 13, 13)))
+        test_to_vec(Symmetric(randn(T, 11, 11)))
+        test_to_vec(Diagonal(randn(T, 7)))
+        test_to_vec(DummyType(randn(T, 2, 9)))
+
+        @testset "$Op" for Op in (Adjoint, Transpose)
+            test_to_vec(Op(randn(T, 4, 4)))
+            test_to_vec(Op(randn(T, 6)))
+            test_to_vec(Op(randn(T, 2, 5)))
+        end
+
+        @testset "Tuples" begin
+            test_to_vec((5, 4))
+            test_to_vec((5, randn(T, 5)))
+            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1))
+            test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
+            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)))
+            test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
+            test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
+        end
+        @testset "Dictionary" begin
+            if T == Float64
+                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)))
+            else
+                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
+            end
         end
     end
 end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -1,3 +1,16 @@
+# Dummy type where length(x::DummyType) ≠ length(first(to_vec(x)))
+struct DummyType{TX<:Matrix}
+    X::TX
+end
+
+function FiniteDifferences.to_vec(x::DummyType)
+    x_vec, back = to_vec(x.X)
+    return x_vec, x_vec -> DummyType(back(x_vec))
+end
+
+Base.:(==)(x::DummyType, y::DummyType) = x.X == y.X
+Base.length(x::DummyType) = size(x.X, 1)
+
 function test_to_vec(x)
     x_vec, back = to_vec(x)
     @test x_vec isa Vector


### PR DESCRIPTION
This is a fairly substantial PR, motivated in no small part by @Roger-luo 's work in #54 .

### Overview

In particular it

1. completely refactors `jacobian` for performance reasons. Our previous implementation was really quite bad (my fault) -- it required ~~O(input_dims^2)~~ O(input_dims * output_dims) function evaluations rather than O(input_dims).
2. refactors `grad` to utilise `jpvp`. `grad` is now a single-line function that utilises the new `jacobian` implementation. This is a substantial drop in code complexity with no loss of functionality, as much of the code that we had before to handle dictionaries etc is completely gone. The result is that `grad` now depends on `to_vec` like everything else in this package.
3. the new implementation of `jacobian` has the pleasing advantage of doing away with the need to pass a `len` parameter around. This is a breaking change, hence the minor version bump.
4. `to_vec` has been moved out of `grad.jl` to emphasise the separation of concerns.

### Benchmarking

```julia
using BenchmarkTools, FiniteDifferences

A = randn(15, 10)
B = randn(10, 12)

@benchmark jacobian($(central_fdm(5, 1)), *, $A, $B)

# master
BenchmarkTools.Trial:
  memory estimate:  1.02 GiB
  allocs estimate:  4520890
  --------------
  minimum time:     637.381 ms (2.42% GC)
  median time:      654.539 ms (2.73% GC)
  mean time:        660.101 ms (2.80% GC)
  maximum time:     691.597 ms (3.33% GC)
  --------------
  samples:          8
  evals/sample:     1

# New code
BenchmarkTools.Trial:
  memory estimate:  15.97 MiB
  allocs estimate:  45663
  --------------
  minimum time:     5.207 ms (0.00% GC)
  median time:      5.380 ms (0.00% GC)
  mean time:        5.627 ms (4.77% GC)
  maximum time:     8.298 ms (13.32% GC)
  --------------
  samples:          888
  evals/sample:     1
```
