### PR TITLE
Revert some of 0.9.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -61,25 +61,17 @@ function to_vec(X::Diagonal)
 end
 
 function to_vec(X::Transpose)
-
-    x_vec, x_from_vec = to_vec(X.parent)
-
     function Transpose_from_vec(x_vec)
-        return Transpose(x_from_vec(x_vec))
+        return Transpose(permutedims(reshape(x_vec, size(X))))
     end
-
-    return x_vec, Transpose_from_vec
+    return vec(Matrix(X)), Transpose_from_vec
 end
 
 function to_vec(X::Adjoint)
-
-    x_vec, x_from_vec = to_vec(X.parent)
-
     function Adjoint_from_vec(x_vec)
-        return Adjoint(x_from_vec(x_vec))
+        return Adjoint(conj!(permutedims(reshape(x_vec, size(X)))))
     end
-
-    return x_vec, Adjoint_from_vec
+    return vec(Matrix(X)), Adjoint_from_vec
 end
 
 # Non-array data structures

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -6,7 +6,7 @@ transformation.
 """
 function to_vec(x::Number)
     function Number_from_vec(x_vec)
-        return oftype(x, first(x_vec))
+        return first(x_vec)
     end
     return [x], Number_from_vec
 end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -55,6 +55,9 @@ end
             test_to_vec(Op(randn(T, 4, 4)))
             test_to_vec(Op(randn(T, 6)))
             test_to_vec(Op(randn(T, 2, 5)))
+
+            A = randn(T, 3, 3)
+            @test reshape(first(to_vec(Op(A))), 3, 3) == Op(A)
         end
 
         @testset "Tuples" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -25,7 +25,6 @@ function test_to_vec(x::T) where {T}
     x_vec, back = to_vec(x)
     @test x_vec isa Vector
     @test x == back(x_vec)
-    @test back(x_vec) isa T
     return nothing
 end
 


### PR DESCRIPTION
As it turns out I was over-zealous with the type checking. Currently if you provide an `Int` input when computing differences, `to_vec` will make it a float if needs be. While it's debatable whether or not this is desirable behaviour, it's clearly breaking if it changes.

The changes to `adjoint` / `transpose` were just wrong, and they've now been reverted and a test added.

@oxinabox I would appreciate it greatly if you could verify whether these changes make all of the `ChainRules` tests pass on your machine. For some reason, but machine is throwing very strange errors in places where CI doesn't have them. I'm not sure whether it's an issue with my Julia install, my computer is dying (it could very well be, it's old and has been behaving a little strangely recently), something else that's weird, or an actual issue with FiniteDifferences.