### PR TITLE
Memoize Coeffs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -156,14 +156,19 @@ function _check_p_q(p::Integer, q::Integer)
 end
 
 # Compute coefficients for the method
+
+const _COEFFS_CACHE = Dict{Tuple{AbstractVector{<:Real}, Integer, Integer}, Vector{Float64}}()
 function _coefs(grid::AbstractVector{<:Real}, p::Integer, q::Integer)
-    # For high precision on the \ we use Rational, and to prevent overflows we use Int128
-    # At the end we go to Float64 for fast floating point math (rather than rational math)
-    C = [Rational{Int128}(g^i) for i in 0:(p - 1), g in grid]
-    x = zeros(Rational{Int128}, p)
-    x[q + 1] = factorial(q)
-    return Float64.(C \ x)
+    return get!(_COEFFS_CACHE, (grid, p, q)) do
+        # For high precision on the \ we use Rational, and to prevent overflows we use Int128
+        # At the end we go to Float64 for fast floating point math (rather than rational math)
+        C = [Rational{Int128}(g^i) for i in 0:(p - 1), g in grid]
+        x = zeros(Rational{Int128}, p)
+        x[q + 1] = factorial(q)
+        return Float64.(C \ x)
+    end
 end
+
 
 # Estimate the bound on the function value and its derivatives at a point
 _estimate_bound(x, cond) = cond * maximum(abs, x) + TINY


### PR DESCRIPTION
Closes #72.
Now we are faster than we were even on 0.9.2 before I made it slow.
This does part of #61 in particular part of this comment
https://github.com/JuliaDiff/FiniteDifferences.jl/pull/61#issuecomment-605456372

Looks like the cause was #65.
Am going to build a fix shortly

First two timings are as per https://github.com/JuliaDiff/FiniteDifferences.jl/issues/72#issuecomment-614141608

### v0.9.5
    44.084013 seconds (80.42 M allocations: 4.397 GiB, 3.80% gc time)
    29.377420 seconds (28.23 M allocations: 1.830 GiB, 1.86% gc time)
    27.364521 seconds (28.23 M allocations: 1.830 GiB, 1.76% gc time)
    27.871987 seconds (28.23 M allocations: 1.830 GiB, 1.79% gc time)

### v0.9.2

    18.984412 seconds (61.60 M allocations: 3.236 GiB, 6.57% gc time)
    1.072190 seconds (10.23 M allocations: 737.725 MiB, 10.14% gc time)
    1.090849 seconds (10.23 M allocations: 737.725 MiB, 9.55% gc time)
    1.072175 seconds (10.23 M allocations: 737.725 MiB, 8.74% gc time)

### With this PR
    10.143730 seconds (40.32 M allocations: 1.860 GiB, 8.13% gc time)
    0.634321 seconds (7.34 M allocations: 243.141 MiB, 7.87% gc time)
    0.631055 seconds (7.34 M allocations: 243.141 MiB, 8.24% gc time)
    0.661258 seconds (7.34 M allocations: 243.141 MiB, 10.92% gc time)

---

## Using timing from #61
```
using BenchmarkTools
using FiniteDifferences

const _fdm = central_fdm(2,1);
const _fdm5 = central_fdm(5,1);

const xs = collect(1:0.1:200);
f(x) = sum(sin, x);
@btime grad($_fdm, $f, $xs);
@btime grad($_fdm5, $f, $xs);
```

We get:

### v0.9.5
```
julia> @btime grad($_fdm, $f, $xs);
  226.006 ms (195137 allocations: 9.54 MiB)

julia> @btime grad($_fdm5, $f, $xs);
  744.445 ms (665012 allocations: 23.76 MiB)
```

### v0.9.2
```
julia> @btime grad($_fdm, $f, $xs);
  221.743 ms (154789 allocations: 4.26 MiB)

julia> @btime grad($_fdm5, $f, $xs);
  440.230 ms (162753 allocations: 5.45 MiB)
```

### With this PR
```
julia> @btime grad($_fdm, $f, $xs);
  199.677 ms (177218 allocations: 6.90 MiB)

julia> @btime grad($_fdm5, $f, $xs);
  404.316 ms (230974 allocations: 11.58 MiB)
```


## Explain

I think the main reason why this gives much more improvement in the test case from #72 than from #61, is that the #61 benchmark declares the fdm objects outside the the hot-loop.
And that is where `_coeffs` are calculated.
Except I think they are also calculated when `adapt` is triggered.
So this helps more there for the `_fdm5` case.