### PR TITLE
Reconstruct Symmetric using uplo, and generalize for Hermitian also

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.10.0"
+version = "0.10.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -55,7 +55,7 @@ end
 
 function to_vec(x::Symmetric)
     function Symmetric_from_vec(x_vec)
-        return Symmetric(reshape(x_vec, size(x)))
+        return Symmetric(reshape(x_vec, size(x)), Symbol(x.uplo))
     end
     return vec(Matrix(x)), Symmetric_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -53,19 +53,12 @@ function to_vec(x::T) where {T<:LinearAlgebra.AbstractTriangular}
     return x_vec, AbstractTriangular_from_vec
 end
 
-function to_vec(x::Symmetric)
-    function Symmetric_from_vec(x_vec)
-        return Symmetric(reshape(x_vec, size(x)), Symbol(x.uplo))
-    end
-    return vec(Matrix(x)), Symmetric_from_vec
-end
-
-function to_vec(x::Hermitian)
+function to_vec(x::T) where {T<:LinearAlgebra.HermOrSym}
     x_vec, back = to_vec(Matrix(x))
-    function Hermitian_from_vec(x_vec)
-        return Hermitian(back(x_vec), Symbol(x.uplo))
+    function HermOrSym_from_vec(x_vec)
+        return T(back(x_vec), x.uplo)
     end
-    return x_vec, Hermitian_from_vec
+    return x_vec, HermOrSym_from_vec
 end
 
 function to_vec(X::Diagonal)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -60,6 +60,14 @@ function to_vec(x::Symmetric)
     return vec(Matrix(x)), Symmetric_from_vec
 end
 
+function to_vec(x::Hermitian)
+    x_vec, back = to_vec(Matrix(x))
+    function Hermitian_from_vec(x_vec)
+        return Hermitian(back(x_vec), Symbol(x.uplo))
+    end
+    return x_vec, Hermitian_from_vec
+end
+
 function to_vec(X::Diagonal)
     function Diagonal_from_vec(x_vec)
         return Diagonal(reshape(x_vec, size(X)...))

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -45,11 +45,20 @@ end
         test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
         test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
         test_to_vec(UpperTriangular(randn(T, 13, 13)))
-        test_to_vec(Symmetric(randn(T, 11, 11)))
         test_to_vec(Diagonal(randn(T, 7)))
         test_to_vec(DummyType(randn(T, 2, 9)))
         test_to_vec(SVector{2, T}(1.0, 2.0))
         test_to_vec(SMatrix{2, 2, T}(1.0, 2.0, 3.0, 4.0))
+
+        @testset "$Op" for Op in (Symmetric, Hermitian)
+            test_to_vec(Op(randn(T, 11, 11)))
+            @testset "$uplo" for uplo in (:L, :U)
+                A = Op(randn(T, 11, 11), uplo)
+                test_to_vec(A)
+                x_vec, back = to_vec(A)
+                @test back(x_vec).uplo == A.uplo
+            end
+        end
 
         @testset "$Op" for Op in (Adjoint, Transpose)
             test_to_vec(Op(randn(T, 4, 4)))


### PR DESCRIPTION
The `to_vec` function for `Hermitian` uses the same approach as used in #85.