### PR TITLE
Implement to_vec for Generator with identity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.10.2"
+version = "0.10.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -107,3 +107,13 @@ function to_vec(d::Dict)
     end
     return d_vec, Dict_from_vec
 end
+
+# Enable basic conversion of generators
+# just identity for now to avoid doing the wrong thing for closures
+function to_vec(g::Base.Generator{<:Any,typeof(identity)})
+    g_vec, back = to_vec(collect(g))
+    function Generator_from_vec(v)
+        return Base.Generator(identity, back(v))
+    end
+    return g_vec, Generator_from_vec
+end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -83,6 +83,12 @@ end
                 test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
             end
         end
+
+        @testset "Generator(identity, x)" begin
+            test_to_vec((x for x in randn(T, 3)))
+            test_to_vec((x for x in randn(T, 3, 4)))
+            test_to_vec((x for x in randn(T, 3, 4, 5)))
+        end
     end
 
     @testset "FillVector" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -85,9 +85,15 @@ end
         end
 
         @testset "Generator(identity, x)" begin
-            test_to_vec((x for x in randn(T, 3)))
-            test_to_vec((x for x in randn(T, 3, 4)))
-            test_to_vec((x for x in randn(T, 3, 4, 5)))
+            for dims in ((3,), (3, 4), (3, 4, 5))
+                xarray = randn(T, dims...)
+                x = (xi for xi in xarray)
+                x_vec, back = to_vec(x)
+                @test x_vec isa Vector
+                @test all(s -> s isa Real, x_vec)
+                @test back(x_vec) isa Base.Generator{typeof(xarray),typeof(identity)}
+                @test collect(back(x_vec)) == xarray
+            end
         end
     end
 

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -87,7 +87,7 @@ end
         @testset "Generator(identity, x)" begin
             for dims in ((3,), (3, 4), (3, 4, 5))
                 xarray = randn(T, dims...)
-                x = (xi for xi in xarray)
+                x = Base.Generator(identity, xarray)
                 x_vec, back = to_vec(x)
                 @test x_vec isa Vector
                 @test all(s -> s isa Real, x_vec)


### PR DESCRIPTION
This PR implements `to_vec` for generators with the identity function. It limits to the identity function until we have a way to handle closures. This should enable FD to be used for testing of functions that take generic iterators, so long as only this simple iterator is used in the test.