### PR TITLE
Stop using linkcheck.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,6 @@ makedocs(
     pages=["Home" => "index.md", "API" => "pages/api.md"],
     authors="Invenia Labs",
     checkdocs=:exports,
-    linkcheck=true,
     repo="https://github.com/JuliaDiff/FiniteDifferences.jl/blob/{commit}{path}#L{line}",
     sitename="FiniteDifferences.jl",
     strict=true,


### PR DESCRIPTION
Documenter marks linkcheck as experimental, and has it disabled by default.
Given removing it will just fix #101  and let us stop wasting time on it, not using an experimental feature seems like a good idea.

https://juliadocs.github.io/Documenter.jl/stable/lib/public/#Documenter.makedocs

> **Experimental keywords**
> 
> In addition to standard arguments there is a set of non-finalized experimental keyword arguments. The behaviour of these may change or they may be removed without deprecation when a minor version changes (i.e. except in patch releases).
> 
> linkcheck – if set to true makedocs uses curl to check the status codes of external-pointing links, to make sure that they are up-to-date. The links and their status codes are printed to the standard output. If strict is also enabled then the build will fail if there are any broken (400+ status code) links. Default: false.
> 
> linkcheck_ignore allows certain URLs to be ignored in linkcheck. The values should be a list of strings (which get matched exactly) or Regex objects. By default nothing is ignored.
> 
> linkcheck_timeout configures how long curl waits (in seconds) for a link request to return a response before giving up. The default is 10 seconds.


Alternatively we could use `linkcheck_ignore` to just ingore the codecov one that keeps causing problems, or try a longer timeout.