### PR TITLE
Tweak Zero to vec

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -155,10 +155,8 @@ end
 
 
 function FiniteDifferences.to_vec(x::AbstractZero)
-    function AbstractZero_from_vec(z)
-        length(z) == 1  || throw(DimensionMismatch("tried to go back to $x from $z"))
-        iszero(first(z)) || throw(DomainError(first(z)))
+    function AbstractZero_from_vec(x_vec::Vector)
         return x
     end
-    return [false], AbstractZero_from_vec
+    return Bool[], AbstractZero_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -76,9 +76,9 @@ function to_vec(x::T) where {T<:LinearAlgebra.HermOrSym}
 end
 
 function to_vec(X::Diagonal)
-    x_vec, diag_from_vec = to_vec(X.diag)
+    x_vec, back = to_vec(Matrix(X))
     function Diagonal_from_vec(x_vec)
-        return Diagonal(diag_from_vec(x_vec))
+        return Diagonal(back(x_vec))
     end
     return x_vec, Diagonal_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -76,9 +76,9 @@ function to_vec(x::T) where {T<:LinearAlgebra.HermOrSym}
 end
 
 function to_vec(X::Diagonal)
-    x_vec, back = to_vec(Matrix(X))
+    x_vec, diag_from_vec = to_vec(X.diag)
     function Diagonal_from_vec(x_vec)
-        return Diagonal(back(x_vec))
+        return Diagonal(diag_from_vec(x_vec))
     end
     return x_vec, Diagonal_from_vec
 end


### PR DESCRIPTION
`to_vec` for `AbstractZero`s was returning a non-empty vector, which is both unnecessary and potentially incorrect (`AbstractZero`s are structural, so if `FiniteDifferences` were to perturb an `AbstractZero`, bad things would presumably happen).