### PR TITLE
Add tests and fixes for to_vec type-stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -116,7 +116,7 @@ function to_vec(x::Tuple)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, x_backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     lengths = map(length, x_vecs)
-    sz = cumsum(lengths)
+    sz = Tuple(cumsum(collect(lengths)))
     function Tuple_from_vec(v)
         map(x_backs, lengths, sz) do x_back, l, s
             return x_back(v[s - l + 1:s])

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -115,10 +115,11 @@ end
 function to_vec(x::Tuple)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, x_backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
-    sz = cumsum(collect(map(length, x_vecs)))
+    lengths = map(length, x_vecs)
+    sz = cumsum(lengths)
     function Tuple_from_vec(v)
-        return ntuple(length(x)) do n
-            return x_backs[n](v[sz[n] - length(x_vecs[n]) + 1:sz[n]])
+        map(x_backs, lengths, sz) do x_back, l, s
+            return x_back(v[s - l + 1:s])
         end
     end
     return reduce(vcat, x_vecs), Tuple_from_vec

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -101,11 +101,11 @@ function to_vec(X::Adjoint)
     return x_vec, Adjoint_from_vec
 end
 
-function to_vec(X::PermutedDimsArray{T, D, P, Pinv} where {T, D}) where {P, Pinv}
-    x_vec, back = to_vec(collect(X))
+function to_vec(X::T) where {T<:PermutedDimsArray}
+    x_vec, back = to_vec(parent(X))
     function PermutedDimsArray_from_vec(x_vec)
-        X_parent = collect(PermutedDimsArray(back(x_vec), Pinv))
-        return PermutedDimsArray(X_parent, P)
+        X_parent = back(x_vec)
+        return T(X_parent)
     end
     return x_vec, PermutedDimsArray_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -116,7 +116,7 @@ function to_vec(x::Tuple)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, x_backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     lengths = map(length, x_vecs)
-    sz = Tuple(cumsum(collect(lengths)))
+    sz = typeof(lengths)(cumsum(collect(lengths)))
     function Tuple_from_vec(v)
         map(x_backs, lengths, sz) do x_back, l, s
             return x_back(v[s - l + 1:s])

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -29,7 +29,9 @@ function to_vec(x::AbstractVector)
         x_Vec = [backs[n](x_vec[sz[n] - length(x_vecs[n]) + 1:sz[n]]) for n in eachindex(x)]
         return oftype(x, x_Vec)
     end
-    return vcat(x_vecs...), Vector_from_vec
+    # handle empty x
+    x_vec = isempty(x_vecs) ? eltype(eltype(x_vecs))[] : reduce(vcat, x_vecs)
+    return x_vec, Vector_from_vec
 end
 
 function to_vec(x::AbstractArray)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -113,7 +113,8 @@ end
 # Non-array data structures
 
 function to_vec(x::Tuple)
-    x_vecs, x_backs = zip(map(to_vec, x)...)
+    x_vecs_and_backs = map(to_vec, x)
+    x_vecs, x_backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     sz = cumsum(collect(map(length, x_vecs)))
     function Tuple_from_vec(v)
         return ntuple(length(x)) do n

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -95,18 +95,18 @@ end
 
         @testset "Tuples" begin
             test_to_vec((5, 4))
-            test_to_vec((5, randn(T, 5)))
+            test_to_vec((5, randn(T, 5)); check_inferred = VERSION ≥ v"1.2")
             test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1); check_inferred = false)
-            test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
+            test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5); check_inferred = VERSION ≥ v"1.2")
             test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)); check_inferred = false)
             test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
             test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
         end
         @testset "NamedTuple" begin
             if T == Float64
-                test_to_vec((a=5, b=randn(10, 11), c=(5, 4, 3)))
+                test_to_vec((a=5, b=randn(10, 11), c=(5, 4, 3)); check_inferred = VERSION ≥ v"1.2")
             else
-                test_to_vec((a=3 + 2im, b=randn(T, 10, 11), c=(5+im, 2-im, 1+im)))
+                test_to_vec((a=3 + 2im, b=randn(T, 10, 11), c=(5+im, 2-im, 1+im)); check_inferred = VERSION ≥ v"1.2")
             end
         end
         @testset "Dictionary" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -34,6 +34,7 @@ function test_to_vec(x::T; check_inferred = true) where {T}
     x_vec, back = to_vec(x)
     @test x_vec isa Vector
     @test all(s -> s isa Real, x_vec)
+    check_inferred && @inferred back(x_vec)
     @test x == back(x_vec)
     return nothing
 end
@@ -95,9 +96,9 @@ end
         @testset "Tuples" begin
             test_to_vec((5, 4))
             test_to_vec((5, randn(T, 5)))
-            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1))
+            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1); check_inferred = false)
             test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5))
-            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)))
+            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)); check_inferred = false)
             test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
             test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
         end
@@ -129,7 +130,7 @@ end
                 x_inner = (2, 3)
                 x_outer = (1, x_inner)
                 x_comp = Composite{typeof(x_outer)}(1, Composite{typeof(x_inner)}(2, 3))
-                test_to_vec(x_comp)
+                test_to_vec(x_comp; check_inferred = false)
             end
         end
 

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -29,7 +29,8 @@ end
 Base.size(x::FillVector) = (x.len,)
 Base.getindex(x::FillVector, n::Int) = x.x
 
-function test_to_vec(x::T) where {T}
+function test_to_vec(x::T; check_inferred = true) where {T}
+    check_inferred && @inferred to_vec(x)
     x_vec, back = to_vec(x)
     @test x_vec isa Vector
     @test all(s -> s isa Real, x_vec)
@@ -50,9 +51,9 @@ end
         test_to_vec(randn(T, 5, 11))
         test_to_vec(randn(T, 13, 17, 19))
         test_to_vec(randn(T, 13, 0, 19))
-        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0])
-        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0])
-        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2))
+        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0]; check_inferred = false)
+        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0]; check_inferred = false)
+        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2); check_inferred = false)
         test_to_vec(UpperTriangular(randn(T, 13, 13)))
         test_to_vec(Diagonal(randn(T, 7)))
         test_to_vec(DummyType(randn(T, 2, 9)))
@@ -106,9 +107,9 @@ end
         end
         @testset "Dictionary" begin
             if T == Float64
-                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)))
+                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)); check_inferred = false)
             else
-                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)))
+                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)); check_inferred = false)
             end
         end
     end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -47,6 +47,9 @@ end
             test_to_vec(.7 + .8im)
             test_to_vec(1 + 2im)
         end
+        test_to_vec(T[])
+        test_to_vec(Vector{T}[])
+        test_to_vec(Matrix{T}[])
         test_to_vec(randn(T, 3))
         test_to_vec(randn(T, 5, 11))
         test_to_vec(randn(T, 13, 17, 19))


### PR DESCRIPTION
Fixes #117 as well as an issue with `to_vec(::Tuple)` being type-unstable.