### PR TITLE
Reimplement to_vec for Symmetric/Hermitian

### DIFF
--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -68,10 +68,11 @@ function to_vec(x::T) where {T<:LinearAlgebra.AbstractTriangular}
 end
 
 function to_vec(x::T) where {T<:LinearAlgebra.HermOrSym}
-    x_vec, back = to_vec(x.uplo === 'U' ? UpperTriangular(triu(x)) : LowerTriangular(tril(x)))
+    ftri(A) = x.uplo === 'U' ? triu(A) : tril(A)
+    x_vec, back = to_vec(ftri(x))
     function HermOrSym_from_vec(x_vec)
         fdual = T <: Symmetric ? transpose : adjoint
-        trix = back(x_vec)
+        trix = ftri(back(x_vec))
         idx = diagind(trix)
         @views trix[idx] .= (trix[idx] .+ fdual(trix)[idx]) ./ 2
         return T(trix, x.uplo)


### PR DESCRIPTION
The current implementation of `to_vec` for `Symmetric`/`Hermitian` doesn't seem quite right. In particular, this implementation makes `j′vp` not compose. See the newly added test for example (this fails on the current version but not this PR).

This is why for testing `rrule`s for functions that take `Symmetric`/`Hermitian` as input in ChainRules, we have not been able to use ChainRulesTestUtils. With this change, that should no longer be the case. Note that this is a breaking change.