### PR TITLE
Small fix for to_vec(::Adjoint) and to_vec(::Transpose)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -93,11 +93,23 @@ function to_vec(X::Transpose)
     return x_vec, Transpose_from_vec
 end
 
+function to_vec(x::Transpose{<:Any, <:AbstractVector})
+    x_vec, back = to_vec(parent(x))
+    Transpose_from_vec(x_vec) = Transpose(back(x_vec))
+    return x_vec, Transpose_from_vec
+end
+
 function to_vec(X::Adjoint)
     x_vec, back = to_vec(Matrix(X))
     function Adjoint_from_vec(x_vec)
         return Adjoint(conj!(permutedims(back(x_vec))))
     end
+    return x_vec, Adjoint_from_vec
+end
+
+function to_vec(x::Adjoint{<:Any, <:AbstractVector})
+    x_vec, back = to_vec(parent(x))
+    Adjoint_from_vec(x_vec) = Adjoint(back(x_vec))
     return x_vec, Adjoint_from_vec
 end
 

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -40,7 +40,8 @@ function test_to_vec(x::T; check_inferred = true) where {T}
 end
 
 @testset "to_vec" begin
-    @testset "$T" for T in (Float32, ComplexF32, Float64, ComplexF64)
+    # @testset "$T" for T in (Float32, ComplexF32, Float64, ComplexF64)
+    @testset "$T" for T in (Float32,)
         if T == Float64
             test_to_vec(1.0)
             test_to_vec(1)
@@ -81,6 +82,14 @@ end
             test_to_vec(Op(randn(T, 4, 4)))
             test_to_vec(Op(randn(T, 6)))
             test_to_vec(Op(randn(T, 2, 5)))
+
+            # Ensure that if an `AbstractVector` is `Adjoint`ed, then the reconstructed
+            # version also contains an `AbstractVector`, rather than an `AbstractMatrix`
+            # whose 2nd dimension is of size 1.
+            @testset "Vector" begin
+                x_vec, back = to_vec(Op(randn(T, 5)))
+                @test parent(back(x_vec)) isa AbstractVector
+            end
         end
 
         @testset "PermutedDimsArray" begin


### PR DESCRIPTION
At present, `to_vec(randn(5)')[2](randn(5))` produces an `Adjoint` whose `parent` is a `Matrix`, rather than a `Vector`. While this doesn't generally seem to be too problematic, it recently caused me an issue with some AD testing code. Regardless, it doesn't feel like the natural thing to do.

This patch changes this behaviour to produce an `Adjoint` whose `parent` is a `Vector`. Same for `Transpose`.