### PR TITLE
Add ChainRules integration test

### DIFF
--- a/.github/workflows/IntegrationTestChainRules.yml
+++ b/.github/workflows/IntegrationTestChainRules.yml
@@ -1,0 +1,30 @@
+name: IntegrationTestChainRules 
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: Julia v${{ matrix.julia-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone ChainRules
+        uses: actions/checkout@v2
+        with:
+          repository: JuliaDiff/ChainRules.jl
+          path: "ChainRules.jl"
+      - name: Run the tests
+        run: julia --project="ChainRules.jl" -e "using Pkg; Pkg.develop(PackageSpec(path=\"./\")); Pkg.update(); Pkg.test()"
+        shell: bash


### PR DESCRIPTION
As proposed in https://github.com/JuliaDiff/FiniteDifferences.jl/issues/132#issuecomment-757393572, this PR adds an integration test workflow for ChainRules (copied from the equivalent workflow used by ChainRulesCore). ChainRules extensively uses FiniteDifferences, and sometimes regressions here are not caught by our test suite but do cause ChainRules failures. This should help us catch these.