### PR TITLE
Constrain type in `to_vec(::AbstractArray/Vector)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.2"
+version = "0.13.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.13.0"
+version = "0.12.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -40,7 +40,7 @@ function to_vec(x::T) where {T}
     return v, structtype_from_vec
 end
 
-function to_vec(x::StridedVector)
+function to_vec(x::Union{SubArray, Base.ReshapedArray, StridedVector})
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     function Vector_from_vec(x_vec)
@@ -53,7 +53,7 @@ function to_vec(x::StridedVector)
     return x_vec, Vector_from_vec
 end
 
-function to_vec(x::Union{SubArray, StridedArray})
+function to_vec(x::Union{SubArray, Base.ReshapedArray, StridedArray})
     x_vec, from_vec = to_vec(vec(x))
 
     function Array_from_vec(x_vec)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -40,7 +40,7 @@ function to_vec(x::T) where {T}
     return v, structtype_from_vec
 end
 
-function to_vec(x::AbstractVector)
+function to_vec(x::StridedVector)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)
     function Vector_from_vec(x_vec)
@@ -53,7 +53,7 @@ function to_vec(x::AbstractVector)
     return x_vec, Vector_from_vec
 end
 
-function to_vec(x::AbstractArray)
+function to_vec(x::Union{SubArray, StridedArray})
     x_vec, from_vec = to_vec(vec(x))
 
     function Array_from_vec(x_vec)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -34,8 +34,8 @@ function to_vec(x::T) where {T}
     v, vals_from_vec = to_vec(vals)
     function structtype_from_vec(v::Vector{<:Real})
         val_vecs = vals_from_vec(v)
-        vals = map((b, v) -> b(v), backs, val_vecs)
-        return T(vals...)
+        values = map((b, v) -> b(v), backs, val_vecs)
+        return T(values...)
     end
     return v, structtype_from_vec
 end

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -63,8 +63,9 @@ function to_vec(x::DenseArray)
     return x_vec, Array_from_vec
 end
 
-
 # Some specific subtypes of AbstractArray.
+to_vec(x::SubArray) = to_vec(copy(x))
+
 function to_vec(x::Base.ReshapedArray{<:Any, 1})
     x_vec, from_vec = to_vec(parent(x))
     function ReshapedArray_from_vec(x_vec)
@@ -73,12 +74,6 @@ function to_vec(x::Base.ReshapedArray{<:Any, 1})
     end
 
     return x_vec, ReshapedArray_from_vec
-end
-
-function to_vec(x::SubArray)
-    x_vec, from_vec = to_vec(x.parent)
-    SubArray_from_vec(x_vec) = view(from_vec(x_vec), x.indices...)
-    return x_vec, SubArray_from_vec
 end
 
 function to_vec(x::T) where {T<:LinearAlgebra.AbstractTriangular}

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -64,8 +64,6 @@ function to_vec(x::DenseArray)
 end
 
 # Some specific subtypes of AbstractArray.
-to_vec(x::SubArray) = to_vec(copy(x))
-
 function to_vec(x::Base.ReshapedArray{<:Any, 1})
     x_vec, from_vec = to_vec(parent(x))
     function ReshapedArray_from_vec(x_vec)
@@ -75,6 +73,11 @@ function to_vec(x::Base.ReshapedArray{<:Any, 1})
 
     return x_vec, ReshapedArray_from_vec
 end
+
+# To return a SubArray we would endup needing to copy the `parent` of `x` in `from_vec`
+# which doesn't seem particularly useful. So we just convert the view into a copy.
+# we might be able to do something more performant but this seems good for now.
+to_vec(x::Base.SubArray) = to_vec(copy(x))
 
 function to_vec(x::T) where {T<:LinearAlgebra.AbstractTriangular}
     x_vec, back = to_vec(Matrix(x))

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -34,6 +34,16 @@ struct Nested
     y::Singleton
 end
 
+# For testing generic subtypes of AbstractArray
+struct WrapperArray{T, N, A<:AbstractArray{T, N}} <: AbstractArray{T, N}
+    data::A
+end
+function WrapperArray(a::AbstractArray{T, N}) where {T, N}
+    return WrapperArray{T, N, AbstractArray{T, N}}(a)
+end
+Base.size(a::WrapperArray) = size(a.data)
+Base.getindex(a::WrapperArray, inds...) = getindex(a.data, inds...)
+
 function test_to_vec(x::T; check_inferred=true) where {T}
     check_inferred && @inferred to_vec(x)
     x_vec, back = to_vec(x)
@@ -181,15 +191,6 @@ end
     end
 
     @testset "WrapperArray" begin
-        struct WrapperArray{T, N, A<:AbstractArray{T, N}} <: AbstractArray{T, N}
-            data::A
-        end
-        function WrapperArray(a::AbstractArray{T, N}) where {T, N}
-            return WrapperArray{T, N, AbstractArray{T, N}}(a)
-        end
-        Base.size(a::WrapperArray) = size(a.data)
-        Base.getindex(a::WrapperArray, inds...) = getindex(a.data, inds...)
-
         wa = WrapperArray(rand(4, 5))
         test_to_vec(wa; check_inferred=false)
     end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -179,4 +179,18 @@ end
         nested = Nested(ThreeFields(1.0, 2.0, "Three"), Singleton())
         test_to_vec(nested; check_inferred=false) # map
     end
+
+    @testset "WrapperArray" begin
+        struct WrapperArray{T, N, A<:AbstractArray{T, N}} <: AbstractArray{T, N}
+            data::A
+        end
+        function WrapperArray(a::AbstractArray{T, N}) where {T, N}
+            return WrapperArray{T, N, AbstractArray{T, N}}(a)
+        end
+        Base.size(a::WrapperArray) = size(a.data)
+        Base.getindex(a::WrapperArray, inds...) = getindex(a.data, inds...)
+
+        wa = WrapperArray(rand(4, 5))
+        test_to_vec(wa)
+    end
 end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -11,12 +11,14 @@ end
 Base.:(==)(x::DummyType, y::DummyType) = x.X == y.X
 Base.length(x::DummyType) = size(x.X, 1)
 
-# A dummy FillVector. This is a type for which the fallback implementation of
-# `to_vec` should fail loudly.
+# A dummy FillVector
 struct FillVector <: AbstractVector{Float64}
     x::Float64
     len::Int
 end
+
+Base.size(x::FillVector) = (x.len,)
+Base.getindex(x::FillVector, n::Int) = x.x
 
 # For testing Composite{ThreeFields}
 struct ThreeFields
@@ -31,9 +33,6 @@ struct Nested
     x::ThreeFields
     y::Singleton
 end
-
-Base.size(x::FillVector) = (x.len,)
-Base.getindex(x::FillVector, n::Int) = x.x
 
 function test_to_vec(x::T; check_inferred = true) where {T}
     check_inferred && @inferred to_vec(x)
@@ -173,9 +172,7 @@ end
     end
 
     @testset "FillVector" begin
-        x = FillVector(5.0, 10)
-        x_vec, from_vec = to_vec(x)
-        @test_throws MethodError from_vec(randn(10))
+        test_to_vec(FillVector(5.0, 10))
     end
 
     @testset "fallback" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -66,8 +66,8 @@ end
         test_to_vec(UpperTriangular(randn(T, 13, 13)))
         test_to_vec(Diagonal(randn(T, 7)))
         test_to_vec(DummyType(randn(T, 2, 9)))
-        test_to_vec(SVector{2, T}(1.0, 2.0))
-        test_to_vec(SMatrix{2, 2, T}(1.0, 2.0, 3.0, 4.0))
+        test_to_vec(SVector{2, T}(1.0, 2.0); check_inferred = false)
+        test_to_vec(SMatrix{2, 2, T}(1.0, 2.0, 3.0, 4.0); check_inferred = false)
         test_to_vec(@view randn(T, 10)[1:4])  # SubArray -- Vector
         test_to_vec(@view randn(T, 10, 2)[1:4, :])  # SubArray -- Matrix
         test_to_vec(Base.ReshapedArray(rand(T, 3, 3), (9,), ()))
@@ -172,7 +172,7 @@ end
     end
 
     @testset "FillVector" begin
-        test_to_vec(FillVector(5.0, 10))
+        test_to_vec(FillVector(5.0, 10); check_inferred=false)
     end
 
     @testset "fallback" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -34,7 +34,7 @@ struct Nested
     y::Singleton
 end
 
-function test_to_vec(x::T; check_inferred = true) where {T}
+function test_to_vec(x::T; check_inferred=true) where {T}
     check_inferred && @inferred to_vec(x)
     x_vec, back = to_vec(x)
     @test x_vec isa Vector
@@ -60,14 +60,14 @@ end
         test_to_vec(randn(T, 5, 11))
         test_to_vec(randn(T, 13, 17, 19))
         test_to_vec(randn(T, 13, 0, 19))
-        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0]; check_inferred = false)
-        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0]; check_inferred = false)
-        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2); check_inferred = false)
+        test_to_vec([1.0, randn(T, 2), randn(T, 1), 2.0]; check_inferred=false)
+        test_to_vec([randn(T, 5, 4, 3), (5, 4, 3), 2.0]; check_inferred=false)
+        test_to_vec(reshape([1.0, randn(T, 5, 4, 3), randn(T, 4, 3), 2.0], 2, 2); check_inferred=false)
         test_to_vec(UpperTriangular(randn(T, 13, 13)))
         test_to_vec(Diagonal(randn(T, 7)))
         test_to_vec(DummyType(randn(T, 2, 9)))
-        test_to_vec(SVector{2, T}(1.0, 2.0); check_inferred = false)
-        test_to_vec(SMatrix{2, 2, T}(1.0, 2.0, 3.0, 4.0); check_inferred = false)
+        test_to_vec(SVector{2, T}(1.0, 2.0); check_inferred=false)
+        test_to_vec(SMatrix{2, 2, T}(1.0, 2.0, 3.0, 4.0); check_inferred=false)
         test_to_vec(@view randn(T, 10)[1:4])  # SubArray -- Vector
         test_to_vec(@view randn(T, 10, 2)[1:4, :])  # SubArray -- Matrix
         test_to_vec(Base.ReshapedArray(rand(T, 3, 3), (9,), ()))
@@ -110,10 +110,10 @@ end
             test_to_vec((5, 4))
             # TODO remove "< 1.6" once https://github.com/JuliaLang/julia/issues/40277
             test_to_vec((5, randn(T, 5)); check_inferred = VERSION ≥ v"1.2" && VERSION < v"1.6")
-            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1); check_inferred = false)
+            test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1); check_inferred=false)
             # TODO remove "< 1.6" once https://github.com/JuliaLang/julia/issues/40277
             test_to_vec((5, randn(T, 4, 3, 2), UpperTriangular(randn(T, 4, 4)), 2.5); check_inferred = VERSION ≥ v"1.2" && VERSION < v"1.6")
-            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)); check_inferred = false)
+            test_to_vec(((6, 5), 3, randn(T, 3, 2, 0, 1)); check_inferred=false)
             test_to_vec((DummyType(randn(T, 2, 7)), DummyType(randn(T, 3, 9))))
             test_to_vec((DummyType(randn(T, 3, 2)), randn(T, 11, 8)))
         end
@@ -126,9 +126,9 @@ end
         end
         @testset "Dictionary" begin
             if T == Float64
-                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)); check_inferred = false)
+                test_to_vec(Dict(:a=>5, :b=>randn(10, 11), :c=>(5, 4, 3)); check_inferred=false)
             else
-                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)); check_inferred = false)
+                test_to_vec(Dict(:a=>3 + 2im, :b=>randn(T, 10, 11), :c=>(5+im, 2-im, 1+im)); check_inferred=false)
             end
         end
     end
@@ -145,7 +145,7 @@ end
                 x_inner = (2, 3)
                 x_outer = (1, x_inner)
                 x_comp = Composite{typeof(x_outer)}(1, Composite{typeof(x_inner)}(2, 3))
-                test_to_vec(x_comp; check_inferred = false)
+                test_to_vec(x_comp; check_inferred=false)
             end
         end
 
@@ -191,6 +191,6 @@ end
         Base.getindex(a::WrapperArray, inds...) = getindex(a.data, inds...)
 
         wa = WrapperArray(rand(4, 5))
-        test_to_vec(wa)
+        test_to_vec(wa; check_inferred=false)
     end
 end


### PR DESCRIPTION
I've looked into whether we can simply constrain the `to_vec` generic `AbstractVector/Array` to `Strided`, and it almost works.

It's just these `ChainRules` tests which need the `SubArray` in the `Union` (I didn't investigate why the `SubArray`s inside the `Strided` `Union` do not contain this case):
https://github.com/JuliaDiff/ChainRules.jl/blob/38caf4bfdb8af616fcbe7626d10699608af21904/test/rulesets/Base/arraymath.jl#L36-L42 

@willtebbutt this seems to solve a lot of issues that we were seeing (https://github.com/JuliaDiff/FiniteDifferences.jl/issues/149, https://github.com/JuliaDiff/FiniteDifferences.jl/issues/141).

Is there a reason we haven't changed this before? I guess partly because it is breaking, but are there any bad things that can happen if we go ahead with this? It seems like using the struct fallback is a better choice for most things that subtype `AbstractArray`s? 