### PR TITLE
make rand_tangent of struct with no perturbable fields return DoesNotExist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -33,7 +33,12 @@ function rand_tangent(rng::AbstractRNG, x::T) where {T}
         tangents = map(field_names) do field_name
             rand_tangent(rng, getfield(x, field_name))
         end
-        return Composite{T}(; NamedTuple{field_names}(tangents)...)
+        if all(tangent isa DoesNotExist for tangent in tangents)
+            # if none of my fields can be perturbed then I can't be perturbed
+            return DoesNotExist()
+        else
+            Composite{T}(; NamedTuple{field_names}(tangents)...)
+        end
     else
         return NO_FIELDS
     end

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -32,9 +32,13 @@ using FiniteDifferences: rand_tangent
         ((a=5.0, b=1), Composite{NamedTuple{(:a, :b), Tuple{Float64, Int}}}),
 
         # structs.
-        (sin, typeof(NO_FIELDS)),
         (Foo(5.0, 4, rand(rng, 3)), Composite{Foo}),
         (Foo(4.0, 3, Foo(5.0, 2, 4)), Composite{Foo}),
+        (sin, typeof(NO_FIELDS)),
+        # all fields DoesNotExist implies DoesNotExist
+        (Pair(:a, "b"), DoesNotExist),
+        (1:10, DoesNotExist),
+        (1:2:10, DoesNotExist),
 
         # LinearAlgebra types (also just structs).
         (


### PR DESCRIPTION
Closes https://github.com/JuliaDiff/FiniteDifferences.jl/issues/149
This is my preferred alternative to  https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/142#issuecomment-829287623


Note that it is **not** the case that if all my fields do not exist then i do not exist,
but it is the case that if all my fields are not perturbable then I am not pertablable.
Which is what `DoesNotExist` actually means, and we should rename it.