### PR TITLE
tag new release to make available on Zenodo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.5"
+version = "0.12.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
I am trying to register ChainRules and related repos at https://zenodo.org/. For a repo to show up though, a new release has to be tagged. Sorry for the noise!
