### PR TITLE
make rand_tangent give only nice numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.10"
+version = "0.12.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -16,7 +16,8 @@ rand_tangent(rng::AbstractRNG, x::Integer) = NoTangent()
 # Try and make nice numbers with short decimal representations for good error messages
 # while also not biasing the sample space too much
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Number}
-    return round(8randn(rng, T), sigdigits=5, base=2)
+    # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
+    return round(9 * randn(rng, T), sigdigits=5, base=2)
 end
 rand_tangent(rng::AbstractRNG, x::Float64) = rand(rng, -9:0.01:9)
 function rand_tangent(rng::AbstractRNG, x::ComplexF64)
@@ -24,7 +25,9 @@ function rand_tangent(rng::AbstractRNG, x::ComplexF64)
 end
 
 #BigFloat/MPFR is finicky about short numbers, this doesn't always work as well as it should
-rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(8randn(rng)), sigdigits=5, base=2)
+
+# multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
+rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), sigdigits=5, base=2)
 
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 rand_tangent(rng::AbstractRNG, x::Adjoint) = adjoint(rand_tangent(rng, parent(x)))

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -16,17 +16,15 @@ rand_tangent(rng::AbstractRNG, x::Integer) = NoTangent()
 # Try and make nice numbers with short decimal representations for good error messages
 # while also not biasing the sample space too much
 function rand_tangent(rng::AbstractRNG, x::T) where {T<:Number}
-    return round(8randn(rng, T), sigdigits=6, base=2)
+    return round(8randn(rng, T), sigdigits=5, base=2)
 end
 rand_tangent(rng::AbstractRNG, x::Float64) = rand(rng, -9:0.01:9)
 function rand_tangent(rng::AbstractRNG, x::ComplexF64)
     return ComplexF64(rand(rng, -9:0.1:9), rand(rng, -9:0.1:9))
 end
 
-
-# TODO: right now Julia don't allow `randn(rng, BigFloat)`
-# see: https://github.com/JuliaLang/julia/issues/17629
-rand_tangent(rng::AbstractRNG, ::BigFloat) = big(rand_tangent(rng, Float64))
+#BigFloat/MPFR is finicky about short numbers, this doesn't always work as well as it should
+rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(8randn(rng)), sigdigits=5, base=2)
 
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 rand_tangent(rng::AbstractRNG, x::Adjoint) = adjoint(rand_tangent(rng, parent(x)))

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -1,7 +1,9 @@
 """
     rand_tangent([rng::AbstractRNG,] x)
 
-Returns a randomly generated tangent vector appropriate for the primal value `x`.
+Returns a arbitary tangent vector _appropriate_ for the primal value `x`.
+Note that despite the name, no promises on the statistical randomness are made.
+Rather it is an arbitary value, that is generated using the `rng`.
 """
 rand_tangent(x) = rand_tangent(Random.GLOBAL_RNG, x)
 
@@ -11,11 +13,20 @@ rand_tangent(rng::AbstractRNG, x::AbstractString) = NoTangent()
 
 rand_tangent(rng::AbstractRNG, x::Integer) = NoTangent()
 
-rand_tangent(rng::AbstractRNG, x::T) where {T<:Number} = randn(rng, T)
+# Try and make nice numbers with short decimal representations for good error messages
+# while also not biasing the sample space too much
+function rand_tangent(rng::AbstractRNG, x::T) where {T<:Number}
+    return round(8randn(rng, T), sigdigits=6, base=2)
+end
+rand_tangent(rng::AbstractRNG, x::Float64) = rand(rng, -9:0.01:9)
+function rand_tangent(rng::AbstractRNG, x::ComplexF64)
+    return ComplexF64(rand(rng, -9:0.1:9), rand(rng, -9:0.1:9))
+end
+
 
 # TODO: right now Julia don't allow `randn(rng, BigFloat)`
 # see: https://github.com/JuliaLang/julia/issues/17629
-rand_tangent(rng::AbstractRNG, ::BigFloat) = big(randn(rng))
+rand_tangent(rng::AbstractRNG, ::BigFloat) = big(rand_tangent(rng, Float64))
 
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 rand_tangent(rng::AbstractRNG, x::Adjoint) = adjoint(rand_tangent(rng, parent(x)))

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -86,4 +86,12 @@ using FiniteDifferences: rand_tangent
         @test x + rand_tangent(x) isa typeof(x)
         @test x + (rand_tangent(x) + rand_tangent(x)) isa typeof(x)
     end
+
+    @testset "niceness of printing" begin
+        for i in 1:50
+            @test length(string(rand_tangent(1.0))) <= 6
+            @test length(string(rand_tangent(1.0 + 1.0im))) <= 12
+            @test length(string(rand_tangent(1f0))) <= 12
+        end
+    end
 end

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -92,6 +92,7 @@ using FiniteDifferences: rand_tangent
             @test length(string(rand_tangent(1.0))) <= 6
             @test length(string(rand_tangent(1.0 + 1.0im))) <= 12
             @test length(string(rand_tangent(1f0))) <= 12
+            @test length(string(rand_tangent(big"1.0"))) <= 8
         end
     end
 end

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -93,7 +93,7 @@ using FiniteDifferences: rand_tangent
             @test length(string(rand_tangent(1.0))) <= 6
             @test length(string(rand_tangent(1.0 + 1.0im))) <= 12
             @test length(string(rand_tangent(1f0))) <= 12
-            @test length(string(rand_tangent(big"1.0"))) <= 9
+            @test length(string(rand_tangent(big"1.0"))) <= 12
         end
     end
 end

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -87,12 +87,13 @@ using FiniteDifferences: rand_tangent
         @test x + (rand_tangent(x) + rand_tangent(x)) isa typeof(x)
     end
 
-    @testset "niceness of printing" begin
+    # Julia 1.6 changed to using Ryu printing algorithm and seems better at printing short
+    VERSION > v"1.6" && @testset "niceness of printing" begin
         for i in 1:50
             @test length(string(rand_tangent(1.0))) <= 6
             @test length(string(rand_tangent(1.0 + 1.0im))) <= 12
             @test length(string(rand_tangent(1f0))) <= 12
-            @test length(string(rand_tangent(big"1.0"))) <= 8
+            @test length(string(rand_tangent(big"1.0"))) <= 9
         end
     end
 end


### PR DESCRIPTION
I don't think we ever cared about rand_tangent giving actual random valuis.
This rigs it so they are ones with fairly short decimal expressions.
(vs the standard for a Float of 19 charater and 42 characters for a Complex).

It is a bit of a balencing act between restricting the sample space, and getting things that are short.

I have 2 stratergies:

1. `round(k*randn(x) sigdigits=n, base=2)` this is I guess pretty general, but it resticts the space to `z*2^-n`.
2. `rand(range)` there are certain ranges of values that floating point can exactly represent. For example all Float's in  `Base` can exactly represent `-9:0.001:9` (but not `-9:0.0001:9`).

I use stratergy 2 for `Float64` and `ComplexF64` (the types we care about the most)
and strategy 1 for everything else.
Though perhaps I should just use `randn(T)` for everything else and not worry about it.
and/Or code the stratergy 2 for Float16, Float32, and the complex versions.


Contributes towards
https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/146

