### PR TITLE
Fix the random seed during testing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,8 @@ struct Foo
    c::Any
 end
 
+Random.seed!(1)
+
 @testset "FiniteDifferences" begin
     include("rand_tangent.jl")
     include("methods.jl")


### PR DESCRIPTION
Should close #169 
the problem is printing of BigFloats only mostly works right using out method.
I am pretty sure this is a bug in julia / MPFR

So we can set the seed to stop ourselves from getting unlucky