### PR TITLE
Add `rand_tangent` for types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.11"
+version = "0.12.12"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -59,3 +59,4 @@ function rand_tangent(rng::AbstractRNG, x::T) where {T}
 end
 
 rand_tangent(rng::AbstractRNG, ::Type) = NoTangent()
+rand_tangent(rng::AbstractRNG, ::Module) = NoTangent()

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -59,4 +59,3 @@ function rand_tangent(rng::AbstractRNG, x::T) where {T}
 end
 
 rand_tangent(rng::AbstractRNG, ::Type) = NoTangent()
-rand_tangent(rng::AbstractRNG, ::Module) = NoTangent()

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -57,3 +57,6 @@ function rand_tangent(rng::AbstractRNG, x::T) where {T}
         Tangent{T}(; NamedTuple{field_names}(tangents)...)
     end
 end
+
+rand_tangent(rng::AbstractRNG, ::Type) = NoTangent()
+rand_tangent(rng::AbstractRNG, ::Module) = NoTangent()

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -11,8 +11,15 @@ using FiniteDifferences: rand_tangent
         (:a, NoTangent),
         (true, NoTangent),
         (4, NoTangent),
-        (FiniteDifferences, NoTangent),
-        (Foo, NoTangent),
+        (FiniteDifferences, NoTangent),  # Module object
+        # Types (not instances of type)
+        (Foo, NoTangent),  
+        (Union{Int, Foo}, NoTangent),
+        (Union{Int, Foo}, NoTangent),
+        (Vector, NoTangent),
+        (Vector{Float64}, NoTangent),
+        (Integer, NoTangent),
+        (Type{<:Real}, NoTangent),
 
         # Numbers.
         (5.0, Float64),

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -11,6 +11,8 @@ using FiniteDifferences: rand_tangent
         (:a, NoTangent),
         (true, NoTangent),
         (4, NoTangent),
+        (FiniteDifferences, NoTangent),
+        (Foo, NoTangent),
 
         # Numbers.
         (5.0, Float64),


### PR DESCRIPTION
So far
```julia
julia> ChainRulesTestUtils.rand_tangent(Float64)
ERROR: StackOverflowError:
Stacktrace:
     [1] rand_tangent(rng::Random._GLOBAL_RNG, x::Module)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:50
     [2] (::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, Core.TypeName})(field_name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:51
     [3] map (repeats 2 times)
       @ ./tuple.jl:216 [inlined]
     [4] rand_tangent(rng::Random._GLOBAL_RNG, x::Core.TypeName)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:50
     [5] (::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, DataType})(field_name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:51
     [6] map(f::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, DataType}, t::NTuple{20, Symbol})
       @ Base ./tuple.jl:226
     [7] rand_tangent(rng::Random._GLOBAL_RNG, x::Type{Float64})
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:50
     [8] (::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, Core.TypeName})(field_name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:51
--- the last 6 lines are repeated 4152 more times ---
 [24921] map (repeats 4 times)
       @ ./tuple.jl:216 [inlined]
 [24922] rand_tangent(rng::Random._GLOBAL_RNG, x::Core.TypeName)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:50
 [24923] (::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, DataType})(field_name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:51
 [24924] map(f::FiniteDifferences.var"#3#5"{Random._GLOBAL_RNG, DataType}, t::NTuple{20, Symbol})
       @ Base ./tuple.jl:226
 [24925] rand_tangent(rng::Random._GLOBAL_RNG, x::Type{Float64})
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:50
 [24926] rand_tangent(x::Type)
       @ FiniteDifferences ~/JuliaEnvs/ChainRulesTestUtils.jl/dev/FiniteDifferences/src/rand_tangent.jl:8
```

with this
```julia
julia> ChainRulesTestUtils.rand_tangent(Float64)
NoTangent()
```

Needed for https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/117