### PR TITLE
WIP: changes needed to support testing of `project`ed tangents

### DIFF
--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -96,11 +96,10 @@ function to_vec(x::T) where {T<:LinearAlgebra.HermOrSym}
 end
 
 function to_vec(X::Diagonal)
-    x_vec, back = to_vec(Matrix(X))
     function Diagonal_from_vec(x_vec)
-        return Diagonal(back(x_vec))
+        return Diagonal(x_vec)
     end
-    return x_vec, Diagonal_from_vec
+    return diag(X), Diagonal_from_vec
 end
 
 function to_vec(X::Transpose)


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRulesCore.jl/pull/380 and https://github.com/JuliaDiff/ChainRules.jl/pull/453 project the tangents in the rules on the correct type. An example is for `Diagonal * Matrix`, the tangent of `Diagonal` is a `Diagonal`, not a `Matrix` (as it used to be so far).

When we `project` the tangent to a `Diagonal` all the off-diagonal elements become zero. To test these, also the finite differencing must only perturb the diagonal elements of the Diagonal, and not densify it as it does now.

I think the reason why the `to_vec(::Diagonal)` used to densify the Diagonal is to be able to test those rules anyway, so this is reverting the hack if I understand this correctly?