### PR TITLE
Rand tangent zero-dimensional arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.13"
+version = "0.12.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rand_tangent.jl
+++ b/src/rand_tangent.jl
@@ -29,6 +29,7 @@ end
 # multiply by 9 to give a bigger range of values tested: no so tightly clustered around 0.
 rand_tangent(rng::AbstractRNG, ::BigFloat) = round(big(9 * randn(rng)), sigdigits=5, base=2)
 
+rand_tangent(rng::AbstractRNG, x::StridedArray{T, 0}) where {T} = fill(rand_tangent(x[1]))
 rand_tangent(rng::AbstractRNG, x::StridedArray) = rand_tangent.(Ref(rng), x)
 rand_tangent(rng::AbstractRNG, x::Adjoint) = adjoint(rand_tangent(rng, parent(x)))
 rand_tangent(rng::AbstractRNG, x::Transpose) = transpose(rand_tangent(rng, parent(x)))

--- a/test/rand_tangent.jl
+++ b/test/rand_tangent.jl
@@ -27,6 +27,8 @@ using FiniteDifferences: rand_tangent
         (big(5.0), BigFloat),
 
         # StridedArrays.
+        (fill(randn(Float32)), Array{Float32, 0}),
+        (fill(randn(Float64)), Array{Float64, 0}),
         (randn(Float32, 3), Vector{Float32}),
         (randn(Complex{Float64}, 2), Vector{Complex{Float64}}),
         (randn(5, 4), Matrix{Float64}),


### PR DESCRIPTION
Fixes #179 

Minor bugfix. Address edge case where `rand_tangent` is called with zero-arrays - i.e. `fill(1.0)` to maintain shape. 
