### PR TITLE
try to handle structs with custom constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.14"
+version = "0.12.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -22,11 +22,14 @@ end
 to_vec(x::Vector{<:Real}) = (x, identity)
 
 # get around the constructors and make the type directly
-@generated function _force_construct(T, args...)
-    return if VERSION >= v"1.3"
-        Expr(:splatnew, :T, :args)
-    else
-        Expr(:new, :T, Any[:(args[$i]) for i in 1:length(args)]...)
+# Note this is moderately evil accessing julia's internals
+if VERSION >= v"1.3"
+    @generated function _force_construct(T, args...)
+        return Expr(:splatnew, :T, :args)
+    end
+else
+    @generated function _force_construct(T, args...)
+        return Expr(:new, :T, Any[:(args[$i]) for i in 1:length(args)]...)
     end
 end
 

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -23,7 +23,7 @@ to_vec(x::Vector{<:Real}) = (x, identity)
 
 # get around the constructors and make the type directly
 @generated function _force_construct(T, args...)
-    return if VERSION >= 1.3
+    return if VERSION >= v"1.3"
         Expr(:splatnew, :T, :args)
     else
         Expr(:new, :T, Any[:(args[$i]) for i in 1:length(args)]...)

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -22,7 +22,13 @@ end
 to_vec(x::Vector{<:Real}) = (x, identity)
 
 # get around the constructors and make the type directly
-@generated _force_construct(T, args...) = Expr(:new, :T, Any[:(args[$i]) for i in 1:length(args)]...)
+@generated function _force_construct(T, args...)
+    return if VERSION >= 1.3
+        Expr(:splatnew, :T, :args)
+    else
+        Expr(:new, :T, Any[:(args[$i]) for i in 1:length(args)]...)
+    end
+end
 
 # Fallback method for `to_vec`. Won't always do what you wanted, but should be fine a decent
 # chunk of the time.

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -35,7 +35,11 @@ function to_vec(x::T) where {T}
     function structtype_from_vec(v::Vector{<:Real})
         val_vecs = vals_from_vec(v)
         values = map((b, v) -> b(v), backs, val_vecs)
-        return T(values...)
+        try
+            return T(values...)
+        catch MethodError
+            return T.name.wrapper(values...)
+        end
     end
     return v, structtype_from_vec
 end

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -44,6 +44,18 @@ end
 Base.size(a::WrapperArray) = size(a.data)
 Base.getindex(a::WrapperArray, inds...) = getindex(a.data, inds...)
 
+# can not construct it from: cca = CustomConstructorArray(rand(2, 2))
+# T = typeof(cca) # CustomConstructorArray{Float64, 2, Matrix{Float64}}
+# T(rand(2, 3)) # errors
+struct CustomConstructorArray{T, N, A<:AbstractArray{T, N}} <: AbstractArray{T, N}
+    data::A
+    function CustomConstructorArray(data::A) where {T, N, A<:AbstractArray{T, N}}
+        return new{T, N, A}(data)
+    end
+end
+Base.size(a::CustomConstructorArray) = size(a.data)
+Base.getindex(a::CustomConstructorArray, inds...) = getindex(a.data, inds...)
+
 function test_to_vec(x::T; check_inferred=true) where {T}
     check_inferred && @inferred to_vec(x)
     x_vec, back = to_vec(x)
@@ -194,5 +206,10 @@ end
     @testset "WrapperArray" begin
         wa = WrapperArray(rand(4, 5))
         test_to_vec(wa; check_inferred=false)
+    end
+
+    @testset "CustomConstructorArray" begin
+        cca = CustomConstructorArray(rand(2, 3))
+        test_to_vec(cca; check_inferred=false)
     end
 end


### PR DESCRIPTION
Before we would see something like:
```julia
julia> cca = CustomConstructorArray(rand(2, 3));

julia> v, b = to_vec(cca); b(v)
T = CustomConstructorArray{Float64, 2, Matrix{Float64}}
ERROR: MethodError: no method matching CustomConstructorArray{Float64, 2, Matrix{Float64}}(::Matrix{Float64})
Stacktrace:
 [1] (::FiniteDifferences.var"#structtype_from_vec#27"{CustomConstructorArray{Float64, 2, Matrix{Float64}}, FiniteDifferences.var"#Tuple_from_vec#43"{Tuple{Int64}, Tuple{Int64}, Tuple{typeof(identity)}}, Tuple{FiniteDifferences.var"#Array_from_vec#32"{Matrix{Float64}, typeof(identity)}}})(v::Vector{Float64})
   @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:39
 [2] top-level scope
   @ REPL[13]:1
```
because there is a custom constructor. Not the best solution (one could imagine trying to figure out what the constructor is), but an improvement over the current state.