### PR TITLE
WIP: Change matrix to_vec semantics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.18"
+version = "0.13.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -68,6 +68,14 @@ function test_to_vec(x::T; check_inferred=true) where {T}
 end
 
 @testset "to_vec" begin
+
+    @testset "Integer" begin
+        # Under ChainRules semantics, Integers cannot be perturbed. `to_vec` is primarily a
+        # tool designed to work with ChainRules, so we employ the same semantics here.
+        test_to_vec(5)
+        @test length(to_vec(5)[1]) == 0
+    end
+
     @testset "$T" for T in (Float32, ComplexF32, Float64, ComplexF64)
         if T == Float64
             test_to_vec(1.0)
@@ -171,6 +179,7 @@ end
         end
 
         @testset "Tuples" begin
+            test_to_vec(())
             test_to_vec((5, 4))
             test_to_vec((5, randn(T, 5)); check_inferred = VERSION ≥ v"1.2") # broken on Julia 1.6.0, fixed on 1.6.1 
             test_to_vec((randn(T, 4), randn(T, 4, 3, 2), 1); check_inferred=false)


### PR DESCRIPTION
Relates to / resolves https://github.com/JuliaDiff/FiniteDifferences.jl/issues/132

Since `ChainRulesTestUtils` no longer relies on checking equality in the `to_vec`ed space (I don't believe), we're freed up to make this change.

In short: after this change, it will generally be a really bad idea to check equality in the `to_vec`ed space (I _think_ it was probably a bad idea anyway to be honest, because it's generally a lossy transformation).

The motivation for making this PR now was that I was trying to implement some `rrule`s, and encountered the issue that `to_vec(rand_tangent(::Diagonal))` and `to_vec(::Diagonal)` yield different sized vectors, which causes problems with `FiniteDifferences`'s `jpvp` and / or `jvp` functionality.

ToDo:
- [ ] check that this doesn't break ChainRules