### PR TITLE
Implement `to_vec` for `DataType`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.18"
+version = "0.12.19"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -235,6 +235,13 @@ function to_vec(d::Dict)
     return d_vec, Dict_from_vec
 end
 
+# types
+function FiniteDifferences.to_vec(x::DataType)
+    function DataType_from_vec(x_vec::Vector)
+        return x
+    end
+    return Bool[], DataType_from_vec
+end
 
 # ChainRulesCore Differentials
 function FiniteDifferences.to_vec(x::Tangent{P}) where{P}

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -196,8 +196,8 @@ end
     end
 
     @testset "DataType" begin
-        test_to_vec(Float64) # isa DataType
-        test_to_vec(Vector) # isa UnionAll
+        test_to_vec(Float64; check_inferred=false) # isa DataType
+        test_to_vec(Vector; check_inferred=false) # isa UnionAll
     end
 
     @testset "ChainRulesCore Differentials" begin

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -195,6 +195,11 @@ end
         end
     end
 
+    @testset "DataType" begin
+        test_to_vec(Float64) # isa DataType
+        test_to_vec(Vector) # isa UnionAll
+    end
+
     @testset "ChainRulesCore Differentials" begin
         @testset "Tangent{Tuple}" begin
             @testset "basic" begin


### PR DESCRIPTION
I am surprised we didn't run into this earlier.
```julia
julia> v, b = to_vec(Float64)
ERROR: StackOverflowError:
Stacktrace:
     [1] fieldnames
       @ ./reflection.jl:177 [inlined]
     [2] to_vec(x::Type{Float64})
       @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:42
     [3] (::FiniteDifferences.var"#206#209"{Core.TypeName})(name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:38
     [4] map (repeats 4 times)
       @ ./tuple.jl:216 [inlined]
     [5] to_vec(x::Core.TypeName)
       @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:54
     [6] (::FiniteDifferences.var"#206#209"{DataType})(name::Symbol)
       @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:38
     [7] map(f::FiniteDifferences.var"#206#209"{DataType}, t::NTuple{20, Symbol})
       @ Base ./tuple.jl:226
     [8] to_vec(x::Type{Float64})
       @ FiniteDifferences ~/JuliaEnvs/test/alex/dev/FiniteDifferences/src/to_vec.jl:54--- the last 6 lines are repeated 3905 more times ---
```
Found since it caused problems with `unflatten` from ParameterHandling. cc @AlexRobson 