### PR TITLE
Run CI on pushes to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
   schedule:


### PR DESCRIPTION
See https://github.com/JuliaDiff/ChainRulesCore.jl/pull/519

though i think docs might also not be working as we don't have the devbranch set?
and are using a very old version of Documentor?
but that is another PR