### PR TITLE
Remove unused type parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.24"
+version = "0.12.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -557,7 +557,7 @@ end
         power::Int=1,
         breaktol::Real=Inf,
         kw_args...
-    ) where T<:AbstractFloat
+    )
 
 Use Richardson extrapolation to extrapolate a finite difference method.
 
@@ -582,7 +582,7 @@ function extrapolate_fdm(
     power::Int=1,
     breaktol::Real=Inf,
     kw_args...
-) where T<:AbstractFloat
+)
     (power == 1 && _is_symmetric(m)) && (power = 2)
     return extrapolate(
         step -> m(f, x, step),


### PR DESCRIPTION
Fixes the warning
```julia
WARNING: method definition for #extrapolate_fdm#17 at /home/david/.julia/packages/FiniteDifferences/VpgIT/src/methods.jl:577 declares type variable T but does not use it.
```
that shows up when loading FiniteDifferences with Julia 1.8.