### PR TITLE
Matrixify Q's in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.25"
+version = "0.12.26"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -153,7 +153,7 @@ end
                 @test all(!isnan, F_vec)
                 @inferred back(F_vec)
                 F_back = back(F_vec)
-                @test F_back.Q == F.Q
+                @test Matrix(F_back.Q) == Matrix(F.Q)
                 @test F_back.R == F.R
 
                 # Make sure the result is consistent despite the arbitrary
@@ -171,7 +171,7 @@ end
                 @test all(!isnan, Q_vec)
                 @inferred back(Q_vec)
                 Q_back = back(Q_vec)
-                @test Q_back == Q
+                @test Matrix(Q_back) == Matrix(Q)
             end
         end
 


### PR DESCRIPTION
The comparison involves elementwise `getindex` anyway, so it should be faster to first compute the matrix and then compare. Also, this will stop working after https://github.com/JuliaLang/julia/pull/46196 is merged.