### PR TITLE
Revert toml bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.26"
+version = "0.12.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
#212 bumped the patch version, but I don't think it needed to since there were no changes to src, and therefore nothing to release (this is discussed somewhere in colprac or something).

@wesselb @dkarrasch are you happy for this reversion to go through and a release to not be made, or is there a reason that I'm not aware of for why a patch release should be made?