### PR TITLE
Fix overflow catch in coeffs function

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -277,7 +277,7 @@ function _coefs(grid, p, q)
     # For high precision on the `\`, we use `Rational`, and to prevent overflows we use
     # `BigInt`. At the end we go to `Float64` for fast floating point math, rather than
     # rational math.
-    C = [Rational{BigInt}(g^i) for i in 0:(p - 1), g in grid]
+    C = [Rational{BigInt}(g)^i for i in 0:(p - 1), g in grid]
     x = zeros(Rational{BigInt}, p)
     x[q + 1] = factorial(big(q))
     return SVector{p}(Float64.(C \ x))


### PR DESCRIPTION
The current implementation doesn't seem to catch integer overflows correctly. Consider the following:

```{julia}
julia> 2^62
4611686018427387904

julia> 2^63
-9223372036854775808

julia> Rational{BigInt}(2^62*2)
-9223372036854775808//1

julia> Rational{BigInt}(2^62)*2
9223372036854775808//1

```