### PR TITLE
support empty tuples and named tuples

### DIFF
--- a/src/to_vec.jl
+++ b/src/to_vec.jl
@@ -227,6 +227,14 @@ end
 
 # Non-array data structures
 
+function to_vec(::Tuple{})
+    vec = Bool[]
+    function Tuple_from_vec(_)
+        return ()
+    end
+    return vec, Tuple_from_vec
+end
+
 function to_vec(x::Tuple)
     x_vecs_and_backs = map(to_vec, x)
     x_vecs, x_backs = first.(x_vecs_and_backs), last.(x_vecs_and_backs)

--- a/test/to_vec.jl
+++ b/test/to_vec.jl
@@ -226,11 +226,23 @@ end
                 x_comp = Tangent{typeof(x_outer)}(1, Tangent{typeof(x_inner)}(2, 3))
                 test_to_vec(x_comp; check_inferred=false)
             end
+
+            @testset "empty" begin
+                x_tup = ()
+                x_comp = Tangent{typeof(x_tup)}(x_tup...)
+                test_to_vec(x_comp)
+            end
         end
 
         @testset "Tangent Struct" begin
             @testset "NamedTuple basic" begin
                 nt = (; a=1.0, b=20.0)
+                comp = Tangent{typeof(nt)}(; nt...)
+                test_to_vec(comp)
+            end
+
+            @testset "NamedTuple empty" begin
+                nt = NamedTuple()
                 comp = Tangent{typeof(nt)}(; nt...)
                 test_to_vec(comp)
             end


### PR DESCRIPTION
On the main branch, `to_vec(t::Tuple{})` fails as it attempts to call `cumsum` on an empty vector of type `Union{}` (obtained by collecting the empty tuple). It is a bit of a corner case, but it can cause `test_rrule` to fail when the output has an empty tuple or named tuple.

This PR specialcases empty tuples to fix that.

On main:

```julia
julia> using FiniteDifferences

julia> v, reconstruct = FiniteDifferences.to_vec(())
ERROR: MethodError: Base.ArithmeticStyle(::Type{Union{}}) is ambiguous.
```

With this PR:

```julia
julia> using FiniteDifferences
[ Info: Precompiling FiniteDifferences [26cc04aa-876d-5657-8c51-4c34ba976000]

julia> v, reconstruct = FiniteDifferences.to_vec(())
(Bool[], FiniteDifferences.var"#Tuple_from_vec#51"())

julia> reconstruct(v)
()
```