### PR TITLE
Relax type constraints to permit AbstractVectors

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -6,7 +6,7 @@ Approximate the Jacobian of `f` at `x` using `fdm`. Results will be returned as 
 version of `x`, and `y_vec` the flattened version of `f(x...)`. Flattening performed by
 [`to_vec`](@ref).
 """
-function jacobian(fdm, f, x::Vector{<:Real}; len=nothing)
+function jacobian(fdm, f, x::AbstractVector{<:Real}; len=nothing)
     len !== nothing && Base.depwarn(
         "`len` keyword argument to `jacobian` is no longer required " *
         "and will not be permitted in the future.",
@@ -40,11 +40,11 @@ end
 replace_arg(x, xs::Tuple, k::Int) = ntuple(p -> p == k ? x : xs[p], length(xs))
 
 """
-    _jvp(fdm, f, x::Vector{<:Real}, ẋ::AbstractVector{<:Real})
+    _jvp(fdm, f, x::AbstractVector{<:Real}, ẋ::AbstractVector{<:Real})
 
 Convenience function to compute `jacobian(f, x) * ẋ`.
 """
-function _jvp(fdm, f, x::Vector{<:Real}, ẋ::Vector{<:Real})
+function _jvp(fdm, f, x::AbstractVector{<:Real}, ẋ::AbstractVector{<:Real})
     return fdm(ε -> f(x .+ ε .* ẋ), zero(eltype(x)))
 end
 
@@ -79,7 +79,7 @@ end
 
 j′vp(fdm, f, ȳ, xs...) = j′vp(fdm, xs->f(xs...), ȳ, xs)[1]
 
-function _j′vp(fdm, f, ȳ::Vector{<:Real}, x::Vector{<:Real})
+function _j′vp(fdm, f, ȳ::AbstractVector{<:Real}, x::AbstractVector{<:Real})
     isempty(x) && return eltype(ȳ)[] # if x is empty, then so is the jacobian and x̄
     return transpose(first(jacobian(fdm, f, x))) * ȳ
 end


### PR DESCRIPTION
I think this is safe.
We do still convert everything to `Vector{<:Real}` via `to_vec`.
But if someone wants to bypass that by defining something like
```
FiniteDifferences.to_vec(x::CuVector{Float32}) = x, y->y
```
then this might make there lives easier.
It is stepping well off the beaten track, but I don't think we get anything from blocking them like this