### PR TITLE
Fix step size calculation if some results are non-deterministic (inf …

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FiniteDifferences"
 uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
-version = "0.12.32"
+version = "0.12.33"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -391,6 +391,7 @@ function _estimate_magnitudes(
         _compute_estimate(m, fs, x, step, m.coefs_neighbourhood[2]),
         _compute_estimate(m, fs, x, step, m.coefs_neighbourhood[3])
     )
+    ∇fs = finite_or_zero(∇fs)
     ∇f_magnitude = maximum(maximum.(abs, ∇fs))
     # Estimate magnitude of `f` in a neighbourhood of `x`.
     f_magnitude = maximum(maximum.(abs, fs))

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -371,11 +371,20 @@ function estimate_step(
     return _limit_step(m, x, step, acc)
 end
 
+function finite_or_zero(fs::AbstractArray{<:Number})
+   ifelse.(isfinite.(fs), fs, zero(fs))
+end
+
+function finite_or_zero(fs::AbstractArray{<:AbstractArray})
+   finite_or_zero.(fs)
+end
+
 function _estimate_magnitudes(
     m::FiniteDifferenceMethod{P,Q}, f::TF, x::T,
 ) where {P,Q,TF,T<:AbstractFloat}
     step = first(estimate_step(m, f, x))
     fs = _eval_function(m, f, x, step)
+    fs = finite_or_zero(fs)
     # Estimate magnitude of `∇f` in a neighbourhood of `x`.
     ∇fs = SVector{3}(
         _compute_estimate(m, fs, x, step, m.coefs_neighbourhood[1]),

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -235,8 +235,8 @@ end
 @testset "jvp: Estimate step correctly for when some terms are nan/infinite" begin
     fdm = FiniteDifferences.central_fdm(5, 1)
     res = jvp(fdm, partial_nan_returning, (3.1, 2.7))
-    @test res[1] ≈ 2.7
+    @test res[2] ≈ 2.7
 
     res = jvp(fdm, partial_nondet_returning, (3.1, 2.7))
-    @test res[1] ≈ 2.7
+    @test res[2] ≈ 2.7
 end

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -217,3 +217,35 @@ using FiniteDifferences: grad, jacobian, _jvp, jvp, j′vp, _j′vp, to_vec
         @test [real(ȳ), imag(ȳ)] ≈ Jy'z̄_vec
     end
 end
+
+using LinearAlgebra
+
+function partial_nan_returning(x)
+    y = Matrix{Float64}(undef, 5, 5)
+    y .= NaN
+    y = Hermitian(y)
+    y .= x
+    return parent(y)
+end
+
+randvar = 1
+function partial_nondet_returning(x)
+    global randvar
+    y = Matrix{Float64}(undef, 5, 5)
+    y .= randvar
+    randvar += 1
+    y = Hermitian(y)
+    y .= x
+    return parent(y)
+end
+
+@testset "jvp: Estimate step correctly for when some terms are nan/infinite" begin
+    fdm = FiniteDifferences.central_fdm(5, 1)
+    res = jvp(fdm, partial_nan_returning, 3.1, 2.7)
+    @show res
+    @test Hermitian(res) .≈ 2.7
+    
+    res = jvp(fdm, partial_nondet_returning, 3.1, 2.7)
+    @show res
+    @test Hermitian(res) .≈ 2.7
+end

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -221,29 +221,22 @@ end
 using LinearAlgebra
 
 function partial_nan_returning(x)
-    y = Matrix{Float64}(undef, 5, 5)
-    y .= NaN
-    y = Hermitian(y)
-    y .= x
-    return parent(y)
+    return Float64[NaN, x]
 end
 
 randvar = 1
 function partial_nondet_returning(x)
     global randvar
-    y = Matrix{Float64}(undef, 5, 5)
-    y .= randvar
+    y = Float64[randvar, x]
     randvar += 1
-    y = Hermitian(y)
-    y .= x
-    return parent(y)
+    return y
 end
 
 @testset "jvp: Estimate step correctly for when some terms are nan/infinite" begin
     fdm = FiniteDifferences.central_fdm(5, 1)
     res = jvp(fdm, partial_nan_returning, (3.1, 2.7))
-    @test all(Hermitian(res) .≈ 2.7)
+    @test res[1] ≈ 2.7
 
     res = jvp(fdm, partial_nondet_returning, (3.1, 2.7))
-    @test all(Hermitian(res) .≈ 2.7)
+    @test res[1] ≈ 2.7
 end

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -241,11 +241,11 @@ end
 
 @testset "jvp: Estimate step correctly for when some terms are nan/infinite" begin
     fdm = FiniteDifferences.central_fdm(5, 1)
-    res = jvp(fdm, partial_nan_returning, 3.1, 2.7)
+    res = jvp(fdm, partial_nan_returning, (3.1, 2.7))
     @show res
     @test Hermitian(res) .≈ 2.7
-    
-    res = jvp(fdm, partial_nondet_returning, 3.1, 2.7)
+
+    res = jvp(fdm, partial_nondet_returning, (3.1, 2.7))
     @show res
     @test Hermitian(res) .≈ 2.7
 end

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -242,10 +242,8 @@ end
 @testset "jvp: Estimate step correctly for when some terms are nan/infinite" begin
     fdm = FiniteDifferences.central_fdm(5, 1)
     res = jvp(fdm, partial_nan_returning, (3.1, 2.7))
-    @show res
-    @test Hermitian(res) .≈ 2.7
+    @test all(Hermitian(res) .≈ 2.7)
 
     res = jvp(fdm, partial_nondet_returning, (3.1, 2.7))
-    @show res
-    @test Hermitian(res) .≈ 2.7
+    @test all(Hermitian(res) .≈ 2.7)
 end


### PR DESCRIPTION
…derivative) or nan

step size is calculated based of the initial derivatives of all results. However, if some of the results return nan and/or are non-determinstic, the step size will be inf/nan, causing all other results to be broken -- instead of just the result which is expected to have an inf/nan derivative

cc @vchuravy @giordano